### PR TITLE
after sending a stdin chunk the connection was flagged as not ready to keep serving

### DIFF
--- a/nailgun-client/ng.c
+++ b/nailgun-client/ng.c
@@ -371,9 +371,6 @@ void processExit(char *buf, unsigned long len) {
  * @param len the number of bytes to send
  */
 void sendStdin(char *buf, unsigned int len) {
-#ifndef WIN32
-  readyToSend = 0;
-#endif
   sendChunk(len, CHUNKTYPE_STDIN, buf);
 }
 
@@ -381,6 +378,9 @@ void sendStdin(char *buf, unsigned int len) {
  * Sends a stdin-eof chunk to the nailgun server
  */
 void processEof() {
+#ifndef WIN32
+  readyToSend = 0;
+#endif
   sendChunk(0, CHUNKTYPE_STDIN_EOF, buf);
 }
 


### PR DESCRIPTION
I guess the flag was meant to be toggled on `processEof` instead of `sendStdin`
