### PR TITLE
Buffer underlying OutputStream in NGOutputStream

### DIFF
--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGOutputStream.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGOutputStream.java
@@ -18,6 +18,7 @@
 
 package com.martiansoftware.nailgun;
 
+import java.io.BufferedOutputStream;
 import java.io.IOException;
 
 /**
@@ -44,7 +45,7 @@ class NGOutputStream extends java.io.DataOutputStream {
 	 * stream (i.e., '1' for stdout, '2' for stderr).
 	 */
 	public NGOutputStream(java.io.OutputStream out, byte streamCode) {
-		super(out);
+		super(new BufferedOutputStream(out));
         this.lock = out;
         this.streamCode = streamCode;
 	}


### PR DESCRIPTION
Previously every call to NGOutputStream.write required six system
calls:

```
19464 sendto(8, "\0", 1, 0, NULL, 0)    = 1
19464 sendto(8, "\0", 1, 0, NULL, 0)    = 1
19464 sendto(8, "\0", 1, 0, NULL, 0)    = 1
19464 sendto(8, "\t", 1, 0, NULL, 0)    = 1
19464 sendto(8, "1", 1, 0, NULL, 0)     = 1
19464 sendto(8, "mymessage", 9, 0, NULL, 0) = 9
```

With this commit write only requires one system call:

```
19089 sendto(8, "\0\0\0\t1mymessage", 14, 0, NULL, 0) = 14
```

Note that all calls to write only buffer the current message and call
flush on the underlying OutputStream before returning.
