### PR TITLE
fix generic support for isatty info

### DIFF
--- a/nailgun-client/ng.c
+++ b/nailgun-client/ng.c
@@ -24,6 +24,7 @@
 #ifdef WIN32
 	#include <direct.h>
 	#include <winsock2.h>
+        #include <io.h>
 #else
 	#include <arpa/inet.h>
 	#include <netdb.h>
@@ -772,17 +773,20 @@ int main(int argc, char *argv[], char *env[]) {
   /* now send environment */  
   sendText(CHUNKTYPE_ENV, NAILGUN_FILESEPARATOR);
   sendText(CHUNKTYPE_ENV, NAILGUN_PATHSEPARATOR);
-#ifndef WIN32
-  /* notify isatty for standard pipes */
-  for(i = 0; i < 3; i++) {
-    sprintf(isattybuf, NAILGUN_TTY_FORMAT, i, isatty(i));
-    sendText(CHUNKTYPE_ENV, isattybuf);
-  }
-#endif
   /* forward the client process environment */
   for(i = 0; env[i]; ++i) {
     sendText(CHUNKTYPE_ENV, env[i]);
   }
+  /* notify isatty for standard pipes */
+  for(i = 0; i < 3; i++) {
+#ifndef WIN32
+    sprintf(isattybuf, NAILGUN_TTY_FORMAT, i, isatty(i));
+#else
+    sprintf(isattybuf, NAILGUN_TTY_FORMAT, i, _isatty(i));
+#endif
+    sendText(CHUNKTYPE_ENV, isattybuf);
+  }
+
   
   /* now send the working directory */
   cwd = getcwd(NULL, 0);


### PR DESCRIPTION
I made this change so that even windows machines have access to to isatty information. I also took the liberty of moving the code that sends the environment /after/ the code that sends the isatty variables. This allows nailgun processes to invoke other nailgun processes and still have the correct value for isatty in the environment.

We are using nailgun at our startup in order to make a java application faster, and this is one of the modifications I made in order to allow our application to detect whether stdin has been redirected to a file or a pipe.
