### PR TITLE
give user application access to underlying input and print streams

### DIFF
--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/ThreadLocalInputStream.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/ThreadLocalInputStream.java
@@ -32,7 +32,7 @@ import java.io.InputStream;
  *  
  * @author <a href="http://www.martiansoftware.com/contact.html">Marty Lamb</a>
  */
-class ThreadLocalInputStream extends InputStream {
+public class ThreadLocalInputStream extends InputStream {
 
     /**
      * The InputStreams for the various threads
@@ -56,7 +56,7 @@ class ThreadLocalInputStream extends InputStream {
      * Sets the InputStream for the current thread
      * @param streamForCurrentThread the InputStream for the current thread
      */
-    void init(InputStream streamForCurrentThread) {
+    public void init(InputStream streamForCurrentThread) {
         streams.set(streamForCurrentThread);
     }
 
@@ -64,7 +64,7 @@ class ThreadLocalInputStream extends InputStream {
      * Returns this thread's InputStream
      * @return this thread's InputStream
      */
-    InputStream getInputStream() {
+    public InputStream getInputStream() {
     	InputStream result = (InputStream) streams.get();
     	return ((result == null) ? defaultInputStream : result);
     }

--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/ThreadLocalPrintStream.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/ThreadLocalPrintStream.java
@@ -32,7 +32,7 @@ import java.io.PrintStream;
  *  
  * @author <a href="http://www.martiansoftware.com/contact.html">Marty Lamb</a>
  */
-class ThreadLocalPrintStream extends PrintStream {
+public class ThreadLocalPrintStream extends PrintStream {
 
     /**
      * The PrintStreams for the various threads
@@ -57,7 +57,7 @@ class ThreadLocalPrintStream extends PrintStream {
      * Sets the PrintStream for the current thread
      * @param streamForCurrentThread the PrintStream for the current thread
      */
-    void init(PrintStream streamForCurrentThread) {
+    public void init(PrintStream streamForCurrentThread) {
         streams.set(streamForCurrentThread);
     }
 
@@ -65,7 +65,7 @@ class ThreadLocalPrintStream extends PrintStream {
      * Returns this thread's PrintStream
      * @return this thread's PrintStream
      */
-    PrintStream getPrintStream() {
+    public PrintStream getPrintStream() {
     	PrintStream result = (PrintStream) streams.get();
     	return ((result == null) ? defaultPrintStream : result);
     }


### PR DESCRIPTION
I made this diff in order to allow nails to modify their own individual System.in/out/err. This is useful if you want to migrate an application to nailgun but it had previously written code that called System.setIn, setOut, setErr, etc.
