### PR TITLE
try to fix race condition causing exit code 227

### DIFF
--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGSession.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGSession.java
@@ -344,8 +344,11 @@ public class NGSession extends Thread {
                     exit.println(NGConstants.EXIT_EXCEPTION); // remote exception constant
                 }
 
+                out.flush();
+                err.flush();
+                exit.flush();
                 sockout.flush();
-                socket.close();
+                socket.shutdownOutput();
 
             } catch (Throwable t) {
                 t.printStackTrace();


### PR DESCRIPTION
Whenever I tried to run nailgun, I would always see intermittent socket disconnects causing the client to return error code 227 before it had finished printing everything to stdout/stderr. After I made this modification to the code, those went away. I believe what is happening is that socket.close does not wait for all the data to be sent to the client before breaking the connection.
