### PR TITLE
Close NGInputStream

### DIFF
--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGSession.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGSession.java
@@ -342,6 +342,8 @@ public class NGSession extends Thread {
                     in.close();
                     t.printStackTrace();
                     exit.println(NGConstants.EXIT_EXCEPTION); // remote exception constant
+                } finally {
+                    in.close();
                 }
 
                 sockout.flush();


### PR DESCRIPTION
Before:
1) start nailgun
2) Observe "ps -o nlwp PID
2) run "ng ng-stats" 10x
4) Observe "ps -o nlwp PID"
5) Shows +20 threads "leaked"
6) jstack -F PID confirms it

After: seems to be resolved. 

Was getting lots of  "java.lang.OutOfMemoryError: unable to create new native thread". Now seems to be resolved (I did reduce Xss as well, so, who knows..)
