### PR TITLE
Use -Xdoclint only on Java 8+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,6 @@
    
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <additionalparam>-Xdoclint:none</additionalparam>
     </properties>
 
     <name>nailgun-all</name>
@@ -85,6 +84,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.9</version>
+                <configuration>
+                    <additionalparam>${javadoc.doclint.none}</additionalparam>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -148,6 +150,15 @@
 					</plugin>
 				</plugins>
 			</build>
+		</profile>
+		<profile>
+			<id>java8-disable-strict-javadoc</id>
+			<activation>
+				<jdk>[1.8,)</jdk>
+			</activation>
+			<properties>
+				<javadoc.doclint.none>-Xdoclint:none</javadoc.doclint.none>
+			</properties>
 		</profile>
 	</profiles>
    


### PR DESCRIPTION
-Xdoclint is invalid on Java 7 and causes a build error.
