### PR TITLE
Don't overwrite NAILGUN_TTY_FORMAT with isatty checks

### DIFF
--- a/nailgun-client/ng.c
+++ b/nailgun-client/ng.c
@@ -666,7 +666,7 @@ int main(int argc, char *argv[], char *env[]) {
   struct hostent *hostinfo;
   char *cmd;
   int firstArgIndex;           /* the first argument _to pass to the server_ */
-  char isattybuf[] = NAILGUN_TTY_FORMAT;
+  char isattybuf[128];
 
   #ifndef WIN32
     fd_set readfds;
@@ -831,7 +831,7 @@ int main(int argc, char *argv[], char *env[]) {
 #ifndef WIN32
   /* notify isatty for standard pipes */
   for(i = 0; i < 3; i++) {
-    sprintf(isattybuf, NAILGUN_TTY_FORMAT, i, isatty(i));
+    snprintf(isattybuf, sizeof isattybuf - 1, NAILGUN_TTY_FORMAT, i, isatty(i));
     sendText(CHUNKTYPE_ENV, isattybuf);
   }
 #endif


### PR DESCRIPTION
I noticed this lovely (ab)use of C in `ng.c`:

  #define NAILGUN_TTY_FORMAT "NAILGUN_TTY_%d=%d"
  char isattybuf[] = NAILGUN_TTY_FORMAT;
  sprintf(isattybuf, NAILGUN_TTY_FORMAT, i, isatty(i));

This actually overwrites the temporary C string literal created by the preprocessor (of which there may be one or many).

It's never a good idea to rely on overwriting C string literals, so this pull request makes it so `isattybuf` is an actual writable byte buffer with a known size.
