### PR TITLE
Use java.util.logging for logging (instead of println)

### DIFF
--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/AliasManager.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/AliasManager.java
@@ -21,6 +21,8 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * An AliasManager is used to store and lookup command Aliases by name. See <a
@@ -30,6 +32,11 @@ import java.util.Set;
  */
 public class AliasManager {
 
+	/**
+	 * {@linkplain Logger} instance for this class.
+	 */
+	private static final Logger LOGGER = Logger.getLogger(AliasManager.class.getName());
+	
     /**
      * actual alias storage
      */
@@ -48,7 +55,7 @@ public class AliasManager {
             props.load(cl.getResourceAsStream("com/martiansoftware/nailgun/builtins/builtins.properties"));
             loadFromProperties(props);
         } catch (java.io.IOException e) {
-            System.err.println("Unable to load builtins.properties: " + e.getMessage());
+            LOGGER.log(Level.SEVERE, "Unable to load builtins.properties", e);
         }
     }
 
@@ -79,7 +86,7 @@ public class AliasManager {
                     String desc = properties.getProperty(key + ".desc", "");
                     addAlias(new Alias(key, desc, clazz));
                 } catch (ClassNotFoundException e) {
-                    System.err.println("Unable to locate class " + properties.getProperty(key));
+                	LOGGER.log(Level.SEVERE, "Unable to locate class " + properties.getProperty(key), e);
                 }
             }
         }

--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGConstants.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGConstants.java
@@ -18,6 +18,8 @@
 package com.martiansoftware.nailgun;
 
 import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Just a simple holder for various NailGun-related contants.
@@ -26,6 +28,11 @@ import java.util.Properties;
  */
 public class NGConstants {
 
+	/**
+	 * {@linkplain Logger} instance for this class.
+	 */
+	private static final Logger LOGGER = Logger.getLogger(NGConstants.class.getName());
+	
     /**
      * The default NailGun port (2113)
      */
@@ -125,7 +132,7 @@ public class NGConstants {
         try {
             props.load(NGConstants.class.getResourceAsStream("/META-INF/maven/com.martiansoftware/nailgun-server/pom.properties"));
         } catch (Exception e) {
-            System.err.println("Unable to load nailgun-version.properties.");
+        	LOGGER.log(Level.SEVERE, "Unable to load nailgun-version.properties", e);
         }
         VERSION  = props.getProperty("version", "[UNKNOWN]");
     }

--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGInputStream.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGInputStream.java
@@ -23,6 +23,8 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * A FilterInputStream that is able to read the chunked stdin stream
@@ -52,13 +54,13 @@ public class NGInputStream extends FilterInputStream implements Closeable {
      * call registered NGClientListeners if a client disconnection is detected.
      * @param in the InputStream to wrap
      * @param out the OutputStream to which SENDINPUT chunks should be sent
-     * @param serverLog the PrintStream to which server logging messages should be written
+     * @param serverLog the {@linkplain Logger} the server uses for logging
      * @param heartbeatTimeoutMillis the interval between heartbeats before considering the client disconnected
      */
     public NGInputStream(
             InputStream in,
             DataOutputStream out,
-            final PrintStream serverLog,
+            final Logger serverLog,
             final int heartbeatTimeoutMillis) {
         super(in);
         din = (DataInputStream) this.in;
@@ -133,12 +135,12 @@ public class NGInputStream extends FilterInputStream implements Closeable {
      * If any of the clientDisconnected methods throw an NGExitException due to calling System.exit()
      * clientDisconnected processing is halted, the exit status is printed to the serverLog and the main
      * thread is interrupted.
-     * @param serverLog The NailGun server log stream.
+     * @param serverLog The NailGun server logger.
      * @param mainThread The thread running nailMain which should be interrupted on System.exit()
      */
-    private synchronized void notifyClientListeners(PrintStream serverLog, Thread mainThread) {
+    private synchronized void notifyClientListeners(Logger serverLog, Thread mainThread) {
         if (! eof) {
-            serverLog.println(mainThread.getName() + " disconnected");
+            serverLog.log(Level.INFO, mainThread.getName() + " disconnected");
             for (Iterator i = clientListeners.iterator(); i.hasNext(); ) {
                 notifyClientListener((NGClientListener) i.next(), mainThread);
             }

--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGServer.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGServer.java
@@ -28,7 +28,9 @@ import java.util.Iterator;
 import java.util.Map;
 
 import com.martiansoftware.nailgun.builtins.DefaultNail;
-import java.util.Properties;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * <p>Listens for new connections from NailGun clients and launches NGSession
@@ -42,6 +44,11 @@ import java.util.Properties;
  */
 public class NGServer implements Runnable {
 
+	/**
+	 * {@linkplain Logger} instance for this class.
+	 */
+	private static final Logger LOGGER = Logger.getLogger(NGServer.class.getName());
+	
     /**
      * Default size for thread pool
      */
@@ -427,20 +434,28 @@ public class NGServer implements Runnable {
             } else {
                 serversocket = new NGUnixDomainServerSocket(listeningAddress.getLocalAddress());
             }
-            while (!shutdown) {
-                sessionOnDeck = sessionPool.take();
-                Socket socket = serversocket.accept();
-                sessionOnDeck.run(socket);
-            }
-
         } catch (Throwable t) {
-            // if shutdown is called while the accept() method is blocking,
-            // an exception will be thrown that we don't care about.  filter
-            // those out.
-            if (!shutdown) {
-                t.printStackTrace();
-            }
+        	getLogger().log(Level.SEVERE, "Failed to create server socket", t);
         }
+        
+        if (serversocket != null) {
+        	LOGGER.log(Level.INFO, getStartMessage());
+	        try {
+	            while (!shutdown) {
+	                sessionOnDeck = sessionPool.take();
+	                Socket socket = serversocket.accept();
+	                sessionOnDeck.run(socket);
+	            }
+	        } catch (Throwable t) {
+	            // if shutdown is called while the accept() method is blocking,
+	            // an exception will be thrown that we don't care about.  filter
+	            // those out.
+	            if (!shutdown) {
+	            	getLogger().log(Level.SEVERE, t.getMessage(), t);
+	            }
+	        }
+        }
+        
         if (sessionOnDeck != null) {
             sessionOnDeck.shutdown();
         }
@@ -524,35 +539,30 @@ public class NGServer implements Runnable {
         t.start();
 
         Runtime.getRuntime().addShutdownHook(new NGServerShutdowner(server));
-
-        String portDescription;
-        if (listeningAddress.isInetAddress() && listeningAddress.getInetPort() == 0) {
-        // if the port is 0, it will be automatically determined.
-        // add this little wait so the ServerSocket can fully
-        // initialize and we can see what port it chose.
-        int runningPort = server.getPort();
-        while (runningPort == 0) {
-            try {
-                Thread.sleep(50);
-            } catch (Throwable toIgnore) {
-            }
-            runningPort = server.getPort();
-        }
-            portDescription = ", port " + runningPort;
-        } else {
-            portDescription = "";
-        }
-
-        System.out.println("NGServer "
-                + NGConstants.VERSION
-                + " started on "
-                + listeningAddress.toString()
-                + portDescription
-                + ".");
     }
 
     public int getHeartbeatTimeout() {
         return heartbeatTimeoutMillis;
+    }
+    
+    public Logger getLogger() {
+		return LOGGER;
+	}
+    
+	private String getStartMessage() {
+		return String.format("%s %s started on %s.", new Object[] {
+				getClass().getSimpleName(),
+				NGConstants.VERSION,
+				listeningAddress.toString()
+		});
+	}
+    
+    private String getStopMessage() {
+		return String.format("%s %s running on %s stopped.", new Object[] {
+				getClass().getSimpleName(),
+				NGConstants.VERSION,
+				listeningAddress.toString()
+		});
     }
 
     /**
@@ -564,10 +574,17 @@ public class NGServer implements Runnable {
      */
     private static class NGServerShutdowner extends Thread {
 
+    	/**
+    	 * {@linkplain Logger} instance for this class.
+    	 */
+    	private static final Logger LOGGER = Logger.getLogger(NGServerShutdowner.class.getName());
+    	
         private NGServer server = null;
+        private String stopMessage;
 
         NGServerShutdowner(NGServer server) {
             this.server = server;
+            this.stopMessage = server.getStopMessage();
         }
 
         public void run() {
@@ -588,9 +605,9 @@ public class NGServer implements Runnable {
             }
 
             if (server.isRunning()) {
-                System.err.println("Unable to cleanly shutdown server.  Exiting JVM Anyway.");
+                LOGGER.log(Level.WARNING, "Unable to cleanly shutdown server. Exiting JVM Anyway.");
             } else {
-                System.out.println("NGServer shut down.");
+                LOGGER.log(Level.INFO, stopMessage);
             }
         }
     }

--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGSession.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGSession.java
@@ -26,6 +26,8 @@ import java.lang.reflect.Method;
 import java.net.Socket;
 import java.util.List;
 import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Reads the NailGun stream from the client through the command, then hands off
@@ -35,8 +37,13 @@ import java.util.Properties;
  * @author <a href="http://www.martiansoftware.com/contact.html">Marty Lamb</a>
  */
 public class NGSession extends Thread {
-
-    /**
+	
+	/**
+	 * {@linkplain Logger} instance for this class.
+	 */
+	private static final Logger LOGGER = Logger.getLogger(NGServer.class.getName());
+	
+	/**
      * The server this NGSession is working for
      */
     private NGServer server = null;
@@ -254,7 +261,7 @@ public class NGSession extends Thread {
                 PrintStream exit = null;
 
                 try {
-                    in = new NGInputStream(sockin, sockout, server.out, heartbeatTimeoutMillis);
+                    in = new NGInputStream(sockin, sockout, server.getLogger(), heartbeatTimeoutMillis);
                     out = new PrintStream(new NGOutputStream(sockout, NGConstants.CHUNKTYPE_STDOUT));
                     err = new PrintStream(new NGOutputStream(sockout, NGConstants.CHUNKTYPE_STDERR));
                     exit = new PrintStream(new NGOutputStream(sockout, NGConstants.CHUNKTYPE_EXIT));
@@ -349,10 +356,11 @@ public class NGSession extends Thread {
                     } catch (NGExitException exitEx) {
                         in.close();
                         exit.println(exitEx.getStatus());
-                        server.out.println(Thread.currentThread().getName() + " exited with status " + exitEx.getStatus());
+                        server.getLogger().log(Level.INFO, Thread.currentThread().getName() + " exited with status " + exitEx.getStatus());
                     } catch (Throwable t) {
                         in.close();
-                        t.printStackTrace();
+                        // t.printStackTrace();
+                        LOGGER.log(Level.SEVERE, t.getMessage(), t);
                         exit.println(NGConstants.EXIT_EXCEPTION); // remote exception constant
                     }
                 } finally {
@@ -375,7 +383,8 @@ public class NGSession extends Thread {
                 }
 
             } catch (Throwable t) {
-                t.printStackTrace();
+                // t.printStackTrace();
+                LOGGER.log(Level.SEVERE, t.getMessage(), t);
             }
 
             ((ThreadLocalInputStream) System.in).init(null);


### PR DESCRIPTION
This improves Nailgun usability on dedicated servers. The administrator can provide the application with a logging.properties file to override its logging behavior. Log messages can be redirected to files or servers (i.e. Graylog2), their formatting can be customized and so on.

The default logging.properties file can be found in the jre/lib directory. To provide a custom file, set the java.util.logging.config.file JVM system property. For example:

`java -Djava.util.logging.config.file=my_logging.properties -jar nailgun.jar`
