### PR TITLE
Fix Windows client MinGW compilation errors and warnings

### DIFF
--- a/nailgun-client/ng.c
+++ b/nailgun-client/ng.c
@@ -68,8 +68,9 @@
 	#define ECONNRESET      104     /* Connection reset by peer */
 #endif
 
-#ifndef socklen_t /* MinGW + winsock */
-	typedef int socklen_t;
+#ifndef __socklen_t_defined /* MinGW + winsock */
+  typedef int socklen_t;
+  #define __socklen_t_defined
 #endif
 
 #ifdef __APPLE__

--- a/nailgun-client/ng.c
+++ b/nailgun-client/ng.c
@@ -678,7 +678,10 @@ int main(int argc, char *argv[], char *env[]) {
   struct hostent *hostinfo;
   char *cmd;
   int firstArgIndex;           /* the first argument _to pass to the server_ */
+
+  #ifndef WIN32
     char isattybuf[] = NAILGUN_TTY_FORMAT;
+  #endif
 
   #ifndef WIN32
     fd_set readfds;

--- a/nailgun-client/ng.c
+++ b/nailgun-client/ng.c
@@ -60,6 +60,18 @@
 	typedef unsigned int SOCKET;
 #endif
 
+#ifndef MSG_NOSIGNAL /* MinGW */
+	#define MSG_NOSIGNAL    0x4000  /* Do not generate SIGPIPE */
+#endif
+
+#ifndef ECONNRESET /* MinGW */
+	#define ECONNRESET      104     /* Connection reset by peer */
+#endif
+
+#ifndef socklen_t /* MinGW + winsock */
+	typedef int socklen_t;
+#endif
+
 #ifdef __APPLE__
   #define SEND_FLAGS 0
 #else
@@ -666,7 +678,7 @@ int main(int argc, char *argv[], char *env[]) {
   struct hostent *hostinfo;
   char *cmd;
   int firstArgIndex;           /* the first argument _to pass to the server_ */
-  char isattybuf[] = NAILGUN_TTY_FORMAT;
+    char isattybuf[] = NAILGUN_TTY_FORMAT;
 
   #ifndef WIN32
     fd_set readfds;


### PR DESCRIPTION
Added some missing symbols (`MSG_NOSIGNAL`, `ECONNRESET`, `socklen_t`) and undefined the `isattybuf` variable for `WIN32` builds where it's not used.
