### PR TITLE
Fix an exception thrown if the user specifies (only) a port to bind to

### DIFF
--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGServer.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGServer.java
@@ -498,7 +498,7 @@ public class NGServer implements Runnable {
             } else {
                 portPart = argParts[0];
             }
-            if (addrPart.equals("local") && portPart != null) {
+            if ("local".equals(addrPart) && portPart != null) {
                 // Treat the port part as a path to a local Unix domain socket
                 // or Windows named pipe.
                 listeningAddress = new NGListeningAddress(portPart);


### PR DESCRIPTION
User specifying the port only makes the `addrPart` variable contain `null`.
