### PR TITLE
fix race between NGInputStream and NGOutputStream on the output socket

### DIFF
--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGInputStream.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGInputStream.java
@@ -333,8 +333,10 @@ public class NGInputStream extends FilterInputStream implements Closeable {
     }
 
     private synchronized void sendSendInput() throws IOException {
-        out.writeInt(0);
-        out.writeByte(NGConstants.CHUNKTYPE_SENDINPUT);
+        synchronized(out) {
+          out.writeInt(0);
+          out.writeByte(NGConstants.CHUNKTYPE_SENDINPUT);
+        }
         out.flush();
         started = true;
     }


### PR DESCRIPTION
This race condition occurs when either NGInputStream or NGOutputStream
begins writing a chunk to the output socket, writes the length of the chunk,
then the chunk type is written incorrectly by the other class. This leads to an
"Unexpected chunk type" error that can occur when a child thread inherits the NGInputStream
and NGOutputStream from its parent thread, and a read of stdin and a write of stdout race with each
other.

We fix this by synchronizing NGInputStream on the underlying DataOutputStream in the same
way which NGOutputStream does.