### PR TITLE
enable to use some hardening flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,13 @@
 # Your compiler location may vary.
 WIN32_CC=/usr/bin/i586-mingw32msvc-gcc
 
-CC=gcc
-CFLAGS=-Wall -pedantic -s -O3
+CFLAGS=-Wall -pedantic -O2
 SRCDIR=nailgun-client
 PREFIX=/usr/local
 
 ng: ${SRCDIR}/ng.c
 	@echo "Building ng client.  To build a Windows binary, type 'make ng.exe'"
-	${CC} ${CFLAGS} -o ng ${SRCDIR}/ng.c
+	${CC} $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o ng ${SRCDIR}/ng.c
 
 install: ng
 	install -d ${PREFIX}/bin


### PR DESCRIPTION
- Maybe CC is not only gcc (e.g. clang)
- add $(CPPFLAGS) and $(LDFLAGS) for hardening
- at least -O3 is not best for default variable, -O2 is better
- sometimes debug information is necessary