### PR TITLE
Buffer underlying OutputStream in NGOutputStream

### DIFF
--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGSession.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGSession.java
@@ -17,6 +17,7 @@
  */
 package com.martiansoftware.nailgun;
 
+import java.io.BufferedOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -262,10 +263,10 @@ public class NGSession extends Thread {
                 // that point the stream from the client will only include stdin and stdin-eof
                 // chunks
                 try (
-                    InputStream in = new NGInputStream(sockin, sockout, heartbeatTimeoutMillis);
-                    PrintStream out = new PrintStream(new NGOutputStream(sockout, NGConstants.CHUNKTYPE_STDOUT));
-                    PrintStream err = new PrintStream(new NGOutputStream(sockout, NGConstants.CHUNKTYPE_STDERR));
-                    PrintStream exit = new PrintStream(new NGOutputStream(sockout, NGConstants.CHUNKTYPE_EXIT));
+                    InputStream in = new NGInputStream(sockin, new DataOutputStream(new BufferedOutputStream(sockout)), heartbeatTimeoutMillis);
+                    PrintStream out = new PrintStream(new NGOutputStream(new BufferedOutputStream(sockout), NGConstants.CHUNKTYPE_STDOUT));
+                    PrintStream err = new PrintStream(new NGOutputStream(new BufferedOutputStream(sockout), NGConstants.CHUNKTYPE_STDERR));
+                    PrintStream exit = new PrintStream(new NGOutputStream(new BufferedOutputStream(sockout), NGConstants.CHUNKTYPE_EXIT));
                 ) {
                     // ThreadLocal streams for System.in/out/err redirection
                     ((ThreadLocalInputStream) System.in).init(in);


### PR DESCRIPTION
Previously every call to NGOutputStream.write required six system
calls:

```
19464 sendto(8, "\0", 1, 0, NULL, 0)    = 1
19464 sendto(8, "\0", 1, 0, NULL, 0)    = 1
19464 sendto(8, "\0", 1, 0, NULL, 0)    = 1
19464 sendto(8, "\t", 1, 0, NULL, 0)    = 1
19464 sendto(8, "1", 1, 0, NULL, 0)     = 1
19464 sendto(8, "mymessage", 9, 0, NULL, 0) = 9
```

With this commit write only requires one system call:

```
19089 sendto(8, "\0\0\0\t1mymessage", 14, 0, NULL, 0) = 14
```

Note that all calls to write only buffer the current message and call
flush on the underlying OutputStream before returning.