### PR TITLE
Refactor input and output streams as thin wrappers

### DIFF
--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGCommunicator.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGCommunicator.java
@@ -1,0 +1,511 @@
+/*
+ * Copyright 2012-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.martiansoftware.nailgun;
+
+import java.io.*;
+import java.net.SocketTimeoutException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Once initial handshaking is complete, handles all reads and writes to the socket with the client
+ * using underlying socket streams. Also handles client disconnect events based on client
+ * heartbeats.
+ */
+public class NGCommunicator implements Closeable {
+
+    private static final Logger LOG = Logger.getLogger(NGCommunicator.class.getName());
+    private final ExecutorService orchestratorExecutor;
+    private final ExecutorService readExecutor;
+    private final DataInputStream in;
+    private final DataOutputStream out;
+    private final Object readLock = new Object();
+    private final Object writeLock = new Object();
+    private final Object orchestratorEvent = new Object();
+    private boolean shutdown = false;
+    private InputStream stdin = null;
+    private boolean eof = false;
+    private boolean closed = false;
+    private int remaining = 0;
+    private AtomicBoolean clientConnected = new AtomicBoolean(true);
+    private final Set<NGClientListener> clientListeners = new HashSet<>();
+    private final Set<NGHeartbeatListener> heartbeatListeners = new HashSet<>();
+    private static final long TERMINATION_TIMEOUT_MS = 1000;
+
+    /**
+     * Creates a new NGCommunicator wrapping the specified InputStream. Also sets up a timer to
+     * periodically consume heartbeats sent from the client and call registered NGClientListeners if
+     * a client disconnection is detected.
+     *
+     * @param in Socket read stream, will be closed with NGCommunicator's close()
+     * @param out Socket write stream, will be closed with NGCommunicator's close()
+     * @param heartbeatTimeoutMillis the interval between heartbeats before considering the client
+     * disconnected
+     */
+    public NGCommunicator(
+        DataInputStream in,
+        DataOutputStream out,
+        final int heartbeatTimeoutMillis) {
+        this.in = in;
+        this.out = out;
+
+        /** Thread factory that overrides name and priority for executor threads */
+        final class NamedThreadFactory implements ThreadFactory {
+
+            private final String threadName;
+
+            public NamedThreadFactory(String threadName) {
+                this.threadName = threadName;
+            }
+
+            @Override
+            public Thread newThread(Runnable r) {
+                SecurityManager s = System.getSecurityManager();
+                ThreadGroup group =
+                    (s != null) ? s.getThreadGroup() : Thread.currentThread().getThreadGroup();
+                Thread t = new Thread(group, r, this.threadName, 0);
+                if (t.isDaemon()) {
+                    t.setDaemon(false);
+                }
+                if (t.getPriority() != Thread.MAX_PRIORITY) {
+                    // warning - it may actually set lower priority if current thread group does not allow
+                    // higher priorities
+                    t.setPriority(Thread.MAX_PRIORITY);
+                }
+                return t;
+            }
+        }
+
+        Thread mainThread = Thread.currentThread();
+        this.orchestratorExecutor = Executors.newSingleThreadExecutor(
+            new NamedThreadFactory(mainThread.getName() + " (NGCommunicator orchestrator)"));
+        this.readExecutor = Executors.newSingleThreadExecutor(
+            new NamedThreadFactory(mainThread.getName() + " (NGCommunicator reader)"));
+
+        // Read timeout, including heartbeats, should be handled by socket.
+        // However Java Socket/Stream API does not enforce that. To stay on safer side,
+        // use timeout on a future
+
+        // let socket timeout first, set rough timeout to 110% of original
+        long futureTimeout = heartbeatTimeoutMillis + heartbeatTimeoutMillis / 10;
+
+        orchestratorExecutor.submit(() -> {
+            try {
+                LOG.log(Level.FINE, "Orchestrator thread started");
+                while (true) {
+                    Future<Byte> readFuture;
+                    synchronized (orchestratorEvent) {
+                        if (shutdown) {
+                            break;
+                        }
+                        readFuture = readExecutor.submit(() -> {
+                            try {
+                                return readChunk();
+                            } catch (IOException e) {
+                                throw new ExecutionException(e);
+                            }
+                        });
+                    }
+
+                    byte chunkType = readFuture.get(futureTimeout, TimeUnit.MILLISECONDS);
+
+                    if (chunkType == NGConstants.CHUNKTYPE_HEARTBEAT) {
+                        notifyHeartbeat();
+                    }
+                }
+            } catch (InterruptedException e) {
+                LOG.log(Level.WARNING, "NGCommunicator orchestrator was interrupted", e);
+            } catch (ExecutionException e) {
+                Throwable cause = getCause(e);
+                if (cause instanceof EOFException) {
+                    // DataInputStream throws EOFException if stream is terminated
+                    // just do nothing and exit main orchestrator thread loop
+                } else if (cause instanceof SocketTimeoutException) {
+                    LOG.log(Level.WARNING,
+                        "Nailgun client socket timed out after " + heartbeatTimeoutMillis
+                            + " ms",
+                        cause);
+                } else {
+                    LOG.log(Level.WARNING, "Nailgun client read future raised an exception",
+                        cause);
+                }
+            } catch (TimeoutException e) {
+                LOG.log(Level.WARNING,
+                    "Nailgun client read future timed out after " + futureTimeout + " ms",
+                    e);
+            } catch (Throwable e) {
+                LOG.log(Level.WARNING,
+                    "Nailgun orchestrator gets an exception ",
+                    e);
+            }
+
+            LOG.log(Level.FINE, "Nailgun client disconnected");
+
+            // set client disconnected flag
+            clientConnected.set(false);
+
+            // notify stream readers there will be no more data
+            setEof();
+
+            // keep orchestrator thread running until signalled to shut up from close()
+            // it is still responsible to notify about client disconnects if listener is
+            // attached after disconnect had really happened
+            waitTerminationAndNotifyClients();
+
+            LOG.log(Level.FINE, "Orchestrator thread finished");
+        });
+    }
+
+    private void waitTerminationAndNotifyClients() {
+        while(true) {
+            List<NGClientListener> listeners = new ArrayList<>();
+            synchronized (orchestratorEvent) {
+                // if shutdown is signalled from close, do not notify client listeners
+                // this can only happen when NGSession has finished processing a nail and
+                // closing
+                if (shutdown) {
+                    return;
+                }
+
+                if (!clientListeners.isEmpty()) {
+                    listeners.addAll(clientListeners);
+                    clientListeners.clear();
+                }
+            }
+
+            // release the lock and notify clients about disconnect
+            for (NGClientListener listener : listeners) {
+                listener.clientDisconnected();
+            }
+
+            synchronized (orchestratorEvent) {
+                if (shutdown || !clientListeners.isEmpty()) {
+                    continue;
+                }
+                try {
+                    // wait for any new other client listener to register, or shutdown
+                    // signal
+                    orchestratorEvent.wait();
+                } catch (InterruptedException e) {
+                    // this thread can only be interrupted from terminateExecutor(), which
+                    // should not ever happen given the normal code flow, so
+                    // just do nothing and quit
+                    return;
+                }
+            }
+        }
+    }
+
+    private static Throwable getCause(Throwable e) {
+        Throwable cause = e.getCause();
+        if (cause == null) {
+            return e;
+        }
+        if (cause instanceof ExecutionException) {
+            return getCause(cause);
+        }
+        return cause;
+    }
+
+    /**
+     * Stop the thread reading from the NailGun client
+     */
+
+    public void close() throws IOException {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        // unblock all waiting readers
+        setEof();
+
+        // signal orchestrator thread it is ok to quit now
+        synchronized (orchestratorEvent) {
+            shutdown = true;
+            orchestratorEvent.notifyAll();
+        }
+
+        // close underlying socket streams - that will cause readExecutor to throw EOFException
+        // and exit orchestrator thread main loop
+        in.close();
+        out.close();
+
+        terminateExecutor(readExecutor, "read");
+        terminateExecutor(orchestratorExecutor, "orchestrator");
+    }
+
+    private static void terminateExecutor(ExecutorService service, String which) {
+        LOG.log(Level.FINE, "Shutting down {0} ExecutorService", which);
+        service.shutdown();
+
+        boolean terminated;
+        try {
+            terminated = service
+                .awaitTermination(TERMINATION_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            // It can happen if a thread calling close() is already interrupted
+            // do not do anything here but do hard shutdown later with shutdownNow()
+            // It is calling thread's responsibility to not be in interrupted state
+            LOG.log(Level.WARNING,
+                "Interruption is signaled in close(), terminating a thread forcefully");
+            service.shutdownNow();
+            return;
+        }
+
+        if (!terminated) {
+            // something went wrong, executor task did not receive a signal and did not complete on time
+            // shot executor in the head then
+            LOG.log(Level.WARNING,
+                "{0} thread did not unblock on a signal within timeout and will be"
+                    + " forcefully terminated",
+                which);
+            service.shutdownNow();
+        }
+    }
+
+    /**
+     * Reads a NailGun chunk payload from {@link #in} and returns an InputStream that reads from
+     * that chunk.
+     *
+     * @param in the InputStream to read the chunk payload from.
+     * @param len the size of the payload chunk read from the chunkHeader.
+     * @return an InputStream containing the read data.
+     * @throws IOException if thrown by the underlying InputStream
+     * @throws EOFException if EOF is reached by underlying stream before the payload has been read,
+     * or if underlying stream was closed
+     */
+    private InputStream readPayload(InputStream in, int len) throws IOException {
+        byte[] receiveBuffer = new byte[len];
+        int totalRead = 0;
+        while (totalRead < len) {
+            int currentRead = in.read(receiveBuffer, totalRead, len - totalRead);
+            if (currentRead < 0) {
+                // server may forcefully close the socket/stream and this will cause InputStream to
+                // return -1. Throw EOFException (same what DataInputStream does) to signal up
+                // that we are in client disconnect mode
+                throw new EOFException("stdin EOF before payload read.");
+            }
+            totalRead += currentRead;
+        }
+        return new ByteArrayInputStream(receiveBuffer);
+    }
+
+    /**
+     * Reads a NailGun chunk header from the underlying InputStream.
+     *
+     * @return type of chunk received
+     * @throws EOFException if underlying stream / socket is closed which happens on client
+     * disconnection
+     * @throws IOException if thrown by the underlying InputStream, or if an unexpected NailGun
+     * chunk type is encountered.
+     */
+    private byte readChunk() throws IOException {
+        int chunkLen = in.readInt();
+        byte chunkType = in.readByte();
+
+        switch (chunkType) {
+            case NGConstants.CHUNKTYPE_STDIN:
+                LOG.log(Level.FINEST, "Got stdin chunk, len {0}", chunkLen);
+                InputStream chunkStream = readPayload(in, chunkLen);
+                setInput(chunkStream, chunkLen);
+                break;
+
+            case NGConstants.CHUNKTYPE_STDIN_EOF:
+                LOG.log(Level.FINEST, "Got stdin closed chunk");
+                setEof();
+                break;
+
+            case NGConstants.CHUNKTYPE_HEARTBEAT:
+                LOG.log(Level.FINEST, "Got client heartbeat");
+                break;
+
+            default:
+                LOG.log(Level.WARNING, "Unknown chunk type: {0}", (char) chunkType);
+                throw new IOException("Unknown stream type: " + (char) chunkType);
+        }
+        return chunkType;
+    }
+
+    private void setInput(InputStream chunkStream, int chunkLen) throws IOException {
+        synchronized (readLock) {
+            if (remaining != 0) {
+                throw new IOException("Data received before stdin stream was emptied");
+            }
+            stdin = chunkStream;
+            remaining = chunkLen;
+            readLock.notifyAll();
+        }
+    }
+
+    /**
+     * Notify threads waiting in read() on either EOF chunk read or client disconnection.
+     */
+    private void setEof() {
+        synchronized (readLock) {
+            eof = true;
+            readLock.notifyAll();
+        }
+    }
+
+    /**
+     * Read data from client's stdin. This function blocks till input is received from the
+     * client.
+     *
+     * @return number of bytes read or -1 if no more data is available
+     * @throws IOException in case of socket error
+     */
+    public int receive(byte[] b, int offset, int length)
+        throws IOException, InterruptedException {
+
+        synchronized (readLock) {
+            if (remaining > 0) {
+                int bytesToRead = Math.min(remaining, length);
+                int result = stdin.read(b, offset, bytesToRead);
+                remaining -= result;
+                return result;
+            }
+            if (eof) {
+                return -1;
+            }
+        }
+
+        // make client know we want more data!
+        sendSendInput();
+
+        synchronized (readLock) {
+            if (remaining == 0 && !eof) {
+                readLock.wait();
+            }
+
+            // at this point we should have data so call itself recursively to utilize
+            // reentrant lock
+            return receive(b, offset, length);
+        }
+    }
+
+    /**
+     * Send data to the client
+     */
+    public void send(byte streamCode, byte[] b, int offset, int len) throws IOException {
+        synchronized (writeLock) {
+            out.writeInt(len);
+            out.writeByte(streamCode);
+            out.write(b, offset, len);
+        }
+        out.flush();
+    }
+
+    private void sendSendInput() throws IOException {
+        synchronized (writeLock) {
+            out.writeInt(0);
+            out.writeByte(NGConstants.CHUNKTYPE_SENDINPUT);
+        }
+        out.flush();
+    }
+
+    /**
+     * @return true if interval since last read is less than heartbeat timeout interval.
+     */
+    public boolean isClientConnected() {
+        return clientConnected.get();
+    }
+
+    /**
+     * @return number of bytes in internal stdin buffer
+     */
+    public int available() {
+        synchronized (readLock) {
+            return remaining;
+        }
+    }
+
+    /**
+     * Registers a new NGClientListener to be called on client disconnection
+     *
+     * @param listener the {@link NGClientListener} to be notified of client events.
+     */
+    public void addClientListener(NGClientListener listener) {
+        synchronized (orchestratorEvent) {
+            clientListeners.add(listener);
+
+            // all notifications are sent from orchestrator thread, so in case if listener is
+            // registered by the time client already disconnected - let orchestrator know it has
+            // new customer
+            orchestratorEvent.notifyAll();
+        }
+    }
+
+    /**
+     * @param listener the {@link NGClientListener} to no longer be notified of client events
+     */
+    public void removeClientListener(NGClientListener listener) {
+        synchronized (orchestratorEvent) {
+            clientListeners.remove(listener);
+        }
+    }
+
+    /**
+     * Do not notify anymore about client disconnects
+     */
+    public void removeAllClientListeners() {
+        synchronized (orchestratorEvent) {
+            clientListeners.clear();
+        }
+    }
+
+    /**
+     * @param listener the {@link NGHeartbeatListener} to be notified of heartbeats
+     */
+    public void addHeartbeatListener(NGHeartbeatListener listener) {
+        synchronized (heartbeatListeners) {
+            heartbeatListeners.add(listener);
+        }
+    }
+
+    /**
+     * @param listener the {@link NGHeartbeatListener} to no longer be notified of heartbeats
+     */
+    public void removeHeartbeatListener(NGHeartbeatListener listener) {
+        synchronized (heartbeatListeners) {
+            heartbeatListeners.remove(listener);
+        }
+    }
+
+    /**
+     * Calls heartbeatReceived method on all registered NGHeartbeatListeners.
+     */
+    private void notifyHeartbeat() {
+        ArrayList<NGHeartbeatListener> listeners;
+        synchronized (heartbeatListeners) {
+            if (heartbeatListeners.isEmpty()) {
+                return;
+            }
+            // copy collection to avoid executing callbacks under lock
+            listeners = new ArrayList<>(heartbeatListeners);
+        }
+
+        for (NGHeartbeatListener listener : listeners) {
+            listener.heartbeatReceived();
+        }
+    }
+}

--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGContext.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGContext.java
@@ -25,286 +25,292 @@ import java.net.NetworkInterface;
 import java.util.Properties;
 
 /**
- * <p>Provides quite a bit of potentially useful information to classes
- * specifically written for NailGun. The <a href="NGServer.html">NailGun server</a> itself, its
- * <a href="AliasManager.html">AliasManager</a>, the remote client's environment variables, and other
- * information is available via this class. For all intents and purposes,
- * the NGContext represents a single connection from a NailGun client.</p>
- * 
+ * <p>Provides quite a bit of potentially useful information to classes specifically written for
+ * NailGun. The <a href="NGServer.html">NailGun server</a> itself, its <a
+ * href="AliasManager.html">AliasManager</a>, the remote client's environment variables, and other
+ * information is available via this class. For all intents and purposes, the NGContext represents a
+ * single connection from a NailGun client.</p>
+ *
  * If a class is written with a
- * 
+ *
  * <pre><code>
  * public static void nailMain(NGContext context)
  * </code></pre>
- * 
+ *
  * method, that method will be called by NailGun instead of the traditional
- * <code>main(String[])</code> method normally used for programs. A fully populated <code>NGContext</code>
- * object will then be provided to <code>nailMain()</code>.
- * 
+ * <code>main(String[])</code> method normally used for programs. A fully populated
+ * <code>NGContext</code> object will then be provided to <code>nailMain()</code>.
+ *
  * @author <a href="http://www.martiansoftware.com/contact.html">Marty Lamb </a>
  */
 public class NGContext {
 
-	/**
-	 * The remote host's environment variables
-	 */
-	private Properties remoteEnvironment = null;
-
-	/**
-	 * The remote host's address
-	 */
-	private InetAddress remoteHost = null;
-
-	/**
-	 * The port on the remote host that is communicating with NailGun
-	 */
-	private int remotePort = 0;
-
-	/**
-	 * Command line arguments for the nail
-	 */
-	private String[] args = null;
-
-	/**
-	 * A stream to which a client exit code can be printed
-	 */
-	private PrintStream exitStream = null;
-
-	/**
-	 * The NGServer that accepted this connection
-	 */
-	private NGServer server = null;
-
-	/**
-	 * The command that was issued for this connection
-	 */
-	private String command = null;
-
-	private String workingDirectory = null;
-	
-	/**
-	 * The client's stdin
-	 */
-	public InputStream in = null;
-
-	/**
-	 * The client's stdout
-	 */
-	public PrintStream out = null;
-
-	/**
-	 * The client's stderr
-	 */
-	public PrintStream err = null;
-
-	
-	/**
-	 * Creates a new, empty NGContext
-	 */
-	public NGContext() {
-		super();
-	}
-	
-	public void setExitStream(PrintStream exitStream) {
-		this.exitStream = exitStream;
-	}
-
-	public void setPort(int remotePort) {
-		this.remotePort = remotePort;
-	}
-
-	public void setCommand(String command) {
-		this.command = command;
-	}
-
-	/**
-	 * Returns the command that was issued by the client (either an alias or the name of a class).
-	 * This allows multiple aliases to point to the same class but result in different behaviors.
-	 * @return the command issued by the client
-	 */
-	public String getCommand() {
-		return (command);
-	}
-	
-	void setWorkingDirectory(String workingDirectory) {
-		this.workingDirectory = workingDirectory;
-	}
-	
-	/**
-	 * Returns the current working directory of the client, as reported by the client.
-	 * This is a String that will use the client's <code>File.separator</code> ('/' or '\'),
-	 * which may differ from the separator on the server. 
-	 * @return the current working directory of the client
-	 */
-	public String getWorkingDirectory() {
-		return (workingDirectory);
-	}
-	
-	void setEnv(Properties remoteEnvironment) {
-		this.remoteEnvironment = remoteEnvironment;
-	}
-
-	void setInetAddress(InetAddress remoteHost) {
-		this.remoteHost = remoteHost;
-	}
-
-	public void setArgs(String[] args) {
-		this.args = args;
-	}
-
-	void setNGServer(NGServer server) {
-		this.server = server;
-	}
-
-	/**
-	 * Returns a <code>java.util.Properties</code> object containing a copy
-	 * of the client's environment variables
-	 * @see java.util.Properties
-	 * @return a <code>java.util.Properties</code> object containing a copy
-	 * of the client's environment variables
-	 */
-	public Properties getEnv() {
-		return (remoteEnvironment);
-	}
-
-	/**
-	 * Returns the file separator ('/' or '\\') used by the client's os.
-	 * @return the file separator ('/' or '\\') used by the client's os.
-	 */
-	public String getFileSeparator() {
-		return (remoteEnvironment.getProperty("NAILGUN_FILESEPARATOR"));
-	}
-	
-	/**
-	 * Returns the path separator (':' or ';') used by the client's os.
-	 * @return the path separator (':' or ';') used by the client's os.
-	 */
-	public String getPathSeparator() {
-		return (remoteEnvironment.getProperty("NAILGUN_PATHSEPARATOR"));		
-	}
-	
-	/**
-	 * Returns the address of the client at the other side of this connection.
-	 * @return the address of the client at the other side of this connection.
-	 */
-	public InetAddress getInetAddress() {
-		return (remoteHost);
-	}
-
-	/**
-	 * Returns the command line arguments for the command
-	 * implementation (nail) on the server.
-	 * @return the command line arguments for the command
-	 * implementation (nail) on the server.
-	 */
-	public String[] getArgs() {
-		return (args);
-	}
-
-	/**
-	 * Returns the NGServer that accepted this connection
-	 * @return the NGServer that accepted this connection
-	 */
-	public NGServer getNGServer() {
-		return (server);
-	}
-
-	/**
-	 * Sends an exit command with the specified exit code to
-	 * the client.  The client will exit immediately with
-	 * the specified exit code; you probably want to return
-	 * from nailMain immediately after calling this.
-	 * 
-	 * @param exitCode the exit code with which the client
-	 * should exit
-	 */
-	public void exit(int exitCode) {
-		exitStream.println(exitCode);
-	}
-
-	/**
-	 * Returns the port on the client connected to the NailGun
-	 * server.
-	 * @return the port on the client connected to the NailGun
-	 * server.
-	 */
-	public int getPort() {
-		return (remotePort);
-	}
-	
-	/**
-	 * Throws a <code>java.lang.SecurityException</code> if the client is not
-	 * connected via the loopback address.
-	 */
-	public void assertLoopbackClient() {
-		if (!getInetAddress().isLoopbackAddress()) {
-			throw (new SecurityException("Client is not at loopback address."));
-		}
-	}
-	
-	/**
-	 * Throws a <code>java.lang.SecurityException</code> if the client is not
-	 * connected from the local machine.
-	 */
-	public void assertLocalClient() {
-		NetworkInterface iface = null;
-		try {
-			iface = NetworkInterface.getByInetAddress(getInetAddress());
-		} catch (java.net.SocketException se) {
-			throw (new SecurityException("Unable to determine if client is local.  Assuming he isn't."));
-		}
-		
-		if ((iface == null) && (!getInetAddress().isLoopbackAddress())) {
-			throw (new SecurityException("Client is not local."));
-		}
-	}
+    /**
+     * The remote host's environment variables
+     */
+    private Properties remoteEnvironment = null;
 
     /**
-     * @return the {@link NGInputStream} for this session.
+     * The remote host's address
      */
-    private NGInputStream getInputStream() {
-        return (NGInputStream) this.in;
+    private InetAddress remoteHost = null;
+
+    /**
+     * The port on the remote host that is communicating with NailGun
+     */
+    private int remotePort = 0;
+
+    /**
+     * Command line arguments for the nail
+     */
+    private String[] args = null;
+
+    /**
+     * A stream to which a client exit code can be printed
+     */
+    private PrintStream exitStream = null;
+
+    /**
+     * The NGServer that accepted this connection
+     */
+    private NGServer server = null;
+
+    /**
+     * The command that was issued for this connection
+     */
+    private String command = null;
+
+    private String workingDirectory = null;
+
+    /**
+     * The client's stdin
+     */
+    public InputStream in = null;
+
+    /**
+     * The client's stdout
+     */
+    public PrintStream out = null;
+
+    /**
+     * The client's stderr
+     */
+    public PrintStream err = null;
+
+    private NGCommunicator communicator = null;
+
+    /**
+     * Creates a new, empty NGContext
+     */
+    public NGContext() {
+    }
+
+    public void setExitStream(PrintStream exitStream) {
+        this.exitStream = exitStream;
+    }
+
+    public void setCommunicator(NGCommunicator comm) {
+        this.communicator = comm;
+    }
+
+    public NGCommunicator getCommunicator() {
+        return this.communicator;
+    }
+
+    public void setPort(int remotePort) {
+        this.remotePort = remotePort;
+    }
+
+    public void setCommand(String command) {
+        this.command = command;
+    }
+
+    /**
+     * Returns the command that was issued by the client (either an alias or the name of a class).
+     * This allows multiple aliases to point to the same class but result in different behaviors.
+     *
+     * @return the command issued by the client
+     */
+    public String getCommand() {
+        return command;
+    }
+
+    void setWorkingDirectory(String workingDirectory) {
+        this.workingDirectory = workingDirectory;
+    }
+
+    /**
+     * Returns the current working directory of the client, as reported by the client. This is a
+     * String that will use the client's <code>File.separator</code> ('/' or '\'), which may differ
+     * from the separator on the server.
+     *
+     * @return the current working directory of the client
+     */
+    public String getWorkingDirectory() {
+        return workingDirectory;
+    }
+
+    void setEnv(Properties remoteEnvironment) {
+        this.remoteEnvironment = remoteEnvironment;
+    }
+
+    void setInetAddress(InetAddress remoteHost) {
+        this.remoteHost = remoteHost;
+    }
+
+    public void setArgs(String[] args) {
+        this.args = args;
+    }
+
+    void setNGServer(NGServer server) {
+        this.server = server;
+    }
+
+    /**
+     * Returns a <code>java.util.Properties</code> object containing a copy of the client's
+     * environment variables
+     *
+     * @return a <code>java.util.Properties</code> object containing a copy of the client's
+     * environment variables
+     * @see java.util.Properties
+     */
+    public Properties getEnv() {
+        return remoteEnvironment;
+    }
+
+    /**
+     * Returns the file separator ('/' or '\\') used by the client's os.
+     *
+     * @return the file separator ('/' or '\\') used by the client's os.
+     */
+    public String getFileSeparator() {
+        return (remoteEnvironment.getProperty("NAILGUN_FILESEPARATOR"));
+    }
+
+    /**
+     * Returns the path separator (':' or ';') used by the client's os.
+     *
+     * @return the path separator (':' or ';') used by the client's os.
+     */
+    public String getPathSeparator() {
+        return (remoteEnvironment.getProperty("NAILGUN_PATHSEPARATOR"));
+    }
+
+    /**
+     * Returns the address of the client at the other side of this connection.
+     *
+     * @return the address of the client at the other side of this connection.
+     */
+    public InetAddress getInetAddress() {
+        return remoteHost;
+    }
+
+    /**
+     * Returns the command line arguments for the command implementation (nail) on the server.
+     *
+     * @return the command line arguments for the command implementation (nail) on the server.
+     */
+    public String[] getArgs() {
+        return args;
+    }
+
+    /**
+     * Returns the NGServer that accepted this connection
+     *
+     * @return the NGServer that accepted this connection
+     */
+    public NGServer getNGServer() {
+        return server;
+    }
+
+    /**
+     * Sends an exit command with the specified exit code to the client.  The client will exit
+     * immediately with the specified exit code; you probably want to return from nailMain
+     * immediately after calling this.
+     *
+     * @param exitCode the exit code with which the client should exit
+     */
+    public void exit(int exitCode) {
+        exitStream.println(exitCode);
+    }
+
+    /**
+     * Returns the port on the client connected to the NailGun server.
+     *
+     * @return the port on the client connected to the NailGun server.
+     */
+    public int getPort() {
+        return (remotePort);
+    }
+
+    /**
+     * Throws a <code>java.lang.SecurityException</code> if the client is not connected via the
+     * loopback address.
+     */
+    public void assertLoopbackClient() {
+        if (!getInetAddress().isLoopbackAddress()) {
+            throw (new SecurityException("Client is not at loopback address."));
+        }
+    }
+
+    /**
+     * Throws a <code>java.lang.SecurityException</code> if the client is not connected from the
+     * local machine.
+     */
+    public void assertLocalClient() {
+        NetworkInterface iface = null;
+        try {
+            iface = NetworkInterface.getByInetAddress(getInetAddress());
+        } catch (java.net.SocketException se) {
+            throw (new SecurityException(
+                "Unable to determine if client is local.  Assuming he isn't."));
+        }
+
+        if ((iface == null) && (!getInetAddress().isLoopbackAddress())) {
+            throw (new SecurityException("Client is not local."));
+        }
     }
 
     /**
      * @return true if client is connected, false if a client exit has been detected.
      */
     public boolean isClientConnected() {
-        return getInputStream().isClientConnected();
+        return communicator.isClientConnected();
     }
 
     /**
      * @param listener the {@link NGClientListener} to be notified of client events.
      */
     public void addClientListener(NGClientListener listener) {
-        getInputStream().addClientListener(listener);
+        communicator.addClientListener(listener);
     }
 
     /**
      * @param listener the {@link NGClientListener} to no longer be notified of client events.
      */
     public void removeClientListener(NGClientListener listener) {
-        getInputStream().removeClientListener(listener);
+        communicator.removeClientListener(listener);
     }
 
-	/**
-	 * Do not notify about client exit
-	 */
-	public void removeAllClientListeners() {
-		getInputStream().removeAllClientListeners();
-	}
+    /**
+     * Do not notify about client exit
+     */
+    public void removeAllClientListeners() {
+        communicator.removeAllClientListeners();
+    }
 
     /**
-     * @param listener the {@link com.martiansoftware.nailgun.NGHeartbeatListener} to be notified of client events.
+     * @param listener the {@link com.martiansoftware.nailgun.NGHeartbeatListener} to be notified of
+     * client events.
      */
     public void addHeartbeatListener(NGHeartbeatListener listener) {
-        getInputStream().addHeartbeatListener(listener);
+        communicator.addHeartbeatListener(listener);
     }
 
     /**
      * @param listener the {@link NGHeartbeatListener} to no longer be notified of client events.
      */
     public void removeHeartbeatListener(NGHeartbeatListener listener) {
-        getInputStream().removeHeartbeatListener(listener);
+        communicator.removeHeartbeatListener(listener);
     }
 }

--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGInputStream.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGInputStream.java
@@ -18,323 +18,39 @@
 
 package com.martiansoftware.nailgun;
 
-import java.io.*;
-import java.net.SocketTimeoutException;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import java.io.IOException;
+import java.io.InputStream;
 
 /**
- * A FilterInputStream that is able to read the chunked stdin stream from a NailGun client.
- *
- * @author <a href="http://www.martiansoftware.com/contact.html">Marty Lamb</a>
+ * Thin layer over NailGun communicator to provide input stream to clients for reading stdin. This
+ * stream is thread-safe.
  */
-public class NGInputStream extends FilterInputStream implements Closeable {
+public class NGInputStream extends InputStream {
 
-    private static final Logger LOG = Logger.getLogger(NGInputStream.class.getName());
-    private final ExecutorService orchestratorExecutor;
-    private final ExecutorService readExecutor;
-    private final DataInputStream din;
-    private InputStream stdin = null;
-    private boolean eof = false;
-    private boolean clientConnected = true;
-    private int remaining = 0;
-    private byte[] oneByteBuffer = null;
-    private final DataOutputStream out;
-    private boolean started = false;
-    private final Set<NGClientListener> clientListeners = new HashSet<>();
-    private final Set<NGHeartbeatListener> heartbeatListeners = new HashSet<>();
-    private static final long TERMINATION_TIMEOUT_MS = 1000;
+    private final NGCommunicator communicator;
+    byte[] buf = new byte[1];
 
     /**
-     * Creates a new NGInputStream wrapping the specified InputStream. Also sets up a timer to
-     * periodically consume heartbeats sent from the client and call registered NGClientListeners if
-     * a client disconnection is detected.
+     * Creates a new NGInputStream over {@link NGCommunicator}
      *
-     * @param in the InputStream to wrap
-     * @param out the OutputStream to which SENDINPUT chunks should be sent
-     * @param heartbeatTimeoutMillis the interval between heartbeats before considering the client
-     * disconnected
+     * @param communicator Lower level communicator which handles all reads from the socket
      */
-    public NGInputStream(
-        DataInputStream in,
-        DataOutputStream out,
-        final int heartbeatTimeoutMillis) {
-        super(in);
-        this.din = in;
-        this.out = out;
-
-        /** Thread factory that overrides name and priority for executor threads */
-        final class NamedThreadFactory implements ThreadFactory {
-
-            private final String threadName;
-
-            public NamedThreadFactory(String threadName) {
-                this.threadName = threadName;
-            }
-
-            @Override
-            public Thread newThread(Runnable r) {
-                SecurityManager s = System.getSecurityManager();
-                ThreadGroup group =
-                    (s != null) ? s.getThreadGroup() : Thread.currentThread().getThreadGroup();
-                Thread t = new Thread(group, r, this.threadName, 0);
-                if (t.isDaemon()) {
-                    t.setDaemon(false);
-                }
-                if (t.getPriority() != Thread.MAX_PRIORITY) {
-                    // warning - it may actually set lower priority if current thread group does not allow
-                    // higher priorities
-                    t.setPriority(Thread.MAX_PRIORITY);
-                }
-                return t;
-            }
-        }
-
-        Thread mainThread = Thread.currentThread();
-        this.orchestratorExecutor = Executors.newSingleThreadExecutor(
-            new NamedThreadFactory(mainThread.getName() + " (NGInputStream orchestrator)"));
-        this.readExecutor = Executors.newSingleThreadExecutor(
-            new NamedThreadFactory(mainThread.getName() + " (NGInputStream reader)"));
-
-        // Read timeout, including heartbeats, should be handled by socket.
-        // However Java Socket/Stream API does not enforce that. To stay on safer side,
-        // use timeout on a future
-
-        // let socket timeout first, set rough timeout to 110% of original
-        long futureTimeout = heartbeatTimeoutMillis + heartbeatTimeoutMillis / 10;
-
-        orchestratorExecutor.submit(() -> {
-            try {
-                boolean isMoreData = true;
-                while (isMoreData) {
-                    Future<Boolean> readFuture = readExecutor.submit(() -> {
-                        try {
-                            // return false if client sends EOF
-                            readChunk();
-                            return true;
-                        } catch (EOFException e) {
-                            // EOFException means that underlying stream is closed by the server
-                            // There will be no more data and it is time to close the circus
-                            return false;
-                        } catch (IOException e) {
-                            throw new ExecutionException(e);
-                        }
-                    });
-
-                    isMoreData = readFuture.get(futureTimeout, TimeUnit.MILLISECONDS);
-                }
-            } catch (InterruptedException e) {
-                LOG.log(Level.WARNING, "Nailgun client read future was interrupted", e);
-            } catch (ExecutionException e) {
-                Throwable cause = e.getCause();
-                if (cause != null && cause instanceof SocketTimeoutException) {
-                    LOG.log(Level.WARNING,
-                        "Nailgun client socket timed out after " + heartbeatTimeoutMillis + " ms",
-                        cause);
-                } else {
-                    LOG.log(Level.WARNING, "Nailgun client read future raised an exception", e);
-                }
-            } catch (TimeoutException e) {
-                LOG.log(Level.WARNING,
-                    "Nailgun client read future timed out after " + futureTimeout + " ms",
-                    e);
-            } finally {
-                LOG.log(Level.FINE, "Nailgun client read shutting down");
-
-                // notify stream readers there are no more data
-                setEof();
-
-                // set client disconnected flag
-                setClientDisconnected();
-
-                // notify listeners that client has disconnected
-                notifyClientListeners();
-            }
-        });
-    }
-
-    /**
-     * Calls clientDisconnected method on all registered NGClientListeners.
-     */
-    private void notifyClientListeners() {
-        // copy collection under monitor to avoid blocking monitor on potentially expensive
-        // callbacks
-        List<NGClientListener> listeners;
-        synchronized (this) {
-            listeners = new ArrayList<>(clientListeners);
-            clientListeners.clear();
-        }
-
-        for (NGClientListener listener : listeners) {
-            listener.clientDisconnected();
-        }
-    }
-
-    /**
-     * Cancel the thread reading from the NailGun client and close underlying input stream
-     */
-    public void close() throws IOException {
-        setEof();
-
-        // this will close `in` and trigger any in.read() calls from readExecutor to unblock
-        super.close();
-
-        // the order or termination is important because readExecutor will send a completion
-        // signal to orchestratorExecutor
-        terminateExecutor(readExecutor, "read");
-        terminateExecutor(orchestratorExecutor, "orchestrator");
-    }
-
-    private static void terminateExecutor(ExecutorService service, String which) {
-        LOG.log(Level.FINE, "Shutting down {0} ExecutorService", which);
-        service.shutdown();
-
-        boolean terminated = false;
-        try {
-            terminated = service
-                .awaitTermination(TERMINATION_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-        } catch (InterruptedException e) {
-            // It can happen if a thread calling close() is already interrupted
-            // do not do anything here but do hard shutdown later with shutdownNow()
-            // It is calling thread's responsibility to not be in interrupted state
-            LOG.log(Level.WARNING,
-                "Interruption is signaled in close(), terminating a thread forcefully");
-            service.shutdownNow();
-            return;
-        }
-
-        if (!terminated) {
-            // something went wrong, executor task did not receive a signal and did not complete on time
-            // shot executor in the head then
-            LOG.log(Level.WARNING,
-                "{0} thread did not unblock on a signal within timeout and will be"
-                    + " forcefully terminated",
-                which);
-            service.shutdownNow();
-        }
-    }
-
-    /**
-     * Reads a NailGun chunk payload from {@link #in} and returns an InputStream that reads from
-     * that chunk.
-     *
-     * @param in the InputStream to read the chunk payload from.
-     * @param len the size of the payload chunk read from the chunkHeader.
-     * @return an InputStream containing the read data.
-     * @throws IOException if thrown by the underlying InputStream
-     * @throws EOFException if EOF is reached by underlying stream
-     * before the payload has been read.
-     */
-    private InputStream readPayload(InputStream in, int len) throws IOException {
-
-        byte[] receiveBuffer = new byte[len];
-        int totalRead = 0;
-        while (totalRead < len) {
-            int currentRead = in.read(receiveBuffer, totalRead, len - totalRead);
-            if (currentRead < 0) {
-                // server may forcefully close the socket/stream and this will cause InputStream to
-                // return -1. Throw EOFException (same what DataInputStream does) to signal up
-                // that we are in shutdown mode
-                throw new EOFException("stdin EOF before payload read.");
-            }
-            totalRead += currentRead;
-        }
-        return new ByteArrayInputStream(receiveBuffer);
-    }
-
-    /**
-     * Reads a NailGun chunk header from the underlying InputStream.
-     *
-     * @throws EOFException if underlying stream / socket is closed which happens on client
-     * disconnection
-     * @throws IOException if thrown by the underlying InputStream, or if an unexpected NailGun
-     * chunk type is encountered.
-     */
-    private void readChunk() throws IOException {
-        int chunkLen = din.readInt();
-        byte chunkType = din.readByte();
-        long readTime = System.currentTimeMillis();
-
-        switch (chunkType) {
-            case NGConstants.CHUNKTYPE_STDIN:
-                InputStream chunkStream = readPayload(in, chunkLen);
-                synchronized (this) {
-                    if (remaining != 0) {
-                        // TODO(buck_team) have better passthru streaming and remove this
-                        // limitation
-                        throw new IOException("Data received before stdin stream was emptied");
-                    }
-                    LOG.log(Level.FINEST, "Got stdin chunk, len {0}", chunkLen);
-                    stdin = chunkStream;
-                    remaining = chunkLen;
-                    notifyAll();
-                }
-                break;
-
-            case NGConstants.CHUNKTYPE_STDIN_EOF:
-                LOG.log(Level.FINEST, "Got stdin closed chunk");
-                setEof();
-                break;
-
-            case NGConstants.CHUNKTYPE_HEARTBEAT:
-                LOG.log(Level.FINEST, "Got client heartbeat");
-
-                ArrayList<NGHeartbeatListener> listeners;
-                synchronized (this) {
-                    // copy collection to avoid executing callbacks under lock
-                    listeners = new ArrayList<>(heartbeatListeners);
-                }
-
-                // TODO(buck_team): should probably dispatch to a different thread(pool)
-                for (NGHeartbeatListener listener : listeners) {
-                    listener.heartbeatReceived();
-                }
-
-                break;
-
-            default:
-                LOG.log(Level.WARNING, "Unknown chunk type: {0}", (char) chunkType);
-                throw new IOException("Unknown stream type: " + (char) chunkType);
-        }
-    }
-
-    /**
-     * Notify threads waiting in read() on either EOF chunk read or client disconnection.
-     */
-    private synchronized void setEof() {
-        eof = true;
-        notifyAll();
-    }
-
-    /**
-     * Notify threads waiting in read() on either EOF chunk read or client disconnection.
-     */
-    private synchronized void setClientDisconnected() {
-        clientConnected = false;
+    public NGInputStream(NGCommunicator communicator){
+        this.communicator = communicator;
     }
 
     /**
      * @see java.io.InputStream#available()
      */
-    public synchronized int available() throws IOException {
-        if (eof) {
-            return 0;
-        }
-        if (stdin == null) {
-            return 0;
-        }
-        return stdin.available();
+    @Override
+    public int available() throws IOException {
+        return communicator.available();
     }
 
     /**
      * @see java.io.InputStream#markSupported()
      */
+    @Override
     public boolean markSupported() {
         return false;
     }
@@ -342,125 +58,30 @@ public class NGInputStream extends FilterInputStream implements Closeable {
     /**
      * @see java.io.InputStream#read()
      */
-    public synchronized int read() throws IOException {
-        if (oneByteBuffer == null) {
-            oneByteBuffer = new byte[1];
+    public int read() throws IOException {
+        // have to synchronize all one byte reads to be able to reuse internal buffer and not
+        // recreate new buffer on heap each time
+        synchronized (buf) {
+            return read(buf, 0, 1) == -1 ? -1 : (int) buf[0];
         }
-        return read(oneByteBuffer, 0, 1) == -1 ? -1 : (int) oneByteBuffer[0];
     }
 
     /**
      * @see java.io.InputStream#read(byte[])
      */
-    public synchronized int read(byte[] b) throws IOException {
+    public int read(byte[] b) throws IOException {
         return read(b, 0, b.length);
     }
 
     /**
      * @see java.io.InputStream#read(byte[], int, int)
      */
-    public synchronized int read(byte[] b, int offset, int length) throws IOException {
-        if (!started) {
-            sendSendInput();
-            started = true;
-        }
-
-        if (remaining == 0) {
-            if (eof) {
-                return -1;
-            }
-
-            try {
-                // wait for monitor to signal for either new data packet or eof (termination)
-                wait();
-            } catch (InterruptedException e) {
-                // this is a signal to stop listening and close
-                // it should never trigger this code path as we always explicitly unblock monitor
-                return -1;
-            }
-        }
-
-        if (remaining == 0) {
-            // still no data, stream/socket is probably terminated; return -1
+    public int read(byte[] b, int offset, int length) throws IOException {
+        try {
+            return communicator.receive(b, offset, length);
+        } catch (InterruptedException e) {
+            // return -1 which means no more data in Java stream world, if thread was terminated
             return -1;
         }
-
-        int bytesToRead = Math.min(remaining, length);
-        int result = stdin.read(b, offset, bytesToRead);
-        remaining -= result;
-        if (remaining == 0) {
-            sendSendInput();
-        }
-
-        return result;
-    }
-
-    private void sendSendInput() throws IOException {
-        // Need to synchronize out because some other thread may write to out too at the same time
-        // hopefully this 'other thread' will synchronize on 'out' as well
-        // also we synchronize on both streams which is a potential deadlock
-        // TODO(buck_team): move acknowledgement packet out of NGInputStream
-        synchronized (out) {
-            out.writeInt(0);
-            out.writeByte(NGConstants.CHUNKTYPE_SENDINPUT);
-        }
-        out.flush();
-    }
-
-    /**
-     * @return true if interval since last read is less than heartbeat timeout interval.
-     */
-    public synchronized boolean isClientConnected() {
-        return clientConnected;
-    }
-
-    /**
-     * Registers a new NGClientListener to be called on client disconnection or calls the listeners
-     * clientDisconnected method if the client has already disconnected to avoid races.
-     *
-     * @param listener the {@link NGClientListener} to be notified of client events.
-     */
-    public void addClientListener(NGClientListener listener) {
-        boolean shouldNotifyNow = false;
-
-        synchronized (this) {
-            if (clientConnected) {
-                clientListeners.add(listener);
-            } else {
-                shouldNotifyNow = true;
-            }
-        }
-
-        if (shouldNotifyNow) {
-            listener.clientDisconnected();
-        }
-    }
-
-    /**
-     * @param listener the {@link NGClientListener} to no longer be notified of client events.
-     */
-    public synchronized void removeClientListener(NGClientListener listener) {
-        clientListeners.remove(listener);
-    }
-
-    /**
-     * Do not notify anymore about client disconnects
-     */
-    public synchronized void removeAllClientListeners() {
-        clientListeners.clear();
-    }
-
-    /**
-     * @param listener the {@link NGHeartbeatListener} to be notified of client events.
-     */
-    public synchronized void addHeartbeatListener(NGHeartbeatListener listener) {
-        heartbeatListeners.add(listener);
-    }
-
-    /**
-     * @param listener the {@link NGClientListener} to no longer be notified of client events.
-     */
-    public synchronized void removeHeartbeatListener(NGHeartbeatListener listener) {
-        heartbeatListeners.remove(listener);
     }
 }

--- a/pynailgun/test_ng.py
+++ b/pynailgun/test_ng.py
@@ -79,8 +79,10 @@ class TestNailgunConnection(unittest.TestCase):
             stdout=subprocess.PIPE
 
         cmd = ['java', '-Djna.nosys=true', '-classpath', self.getClassPath()]
-        if os.environ.get('DEBUG_MODE') == '1':
-            cmd.append('-agentlib:jdwp=transport=dt_socket,address=localhost:8888,server=y,suspend=y')
+        debug_mode = os.environ.get('DEBUG_MODE') or ''
+        if debug_mode != '':
+            suspend = 'n' if debug_mode == '2' else 'y'
+            cmd.append('-agentlib:jdwp=transport=dt_socket,address=localhost:8888,server=y,suspend=' + suspend)
         cmd = cmd + ['com.martiansoftware.nailgun.NGServer', self.transport_address]
 
         self.ng_server_process = subprocess.Popen(


### PR DESCRIPTION
Move all socket read/write logic into separate class (NGCommunicator). Both input and output streams now are tiny data accessors. This allows NailGun to fully control socket lifetime and perform proper synchronization of socket writes.
Session shutdown procedure was also improved by properly closing executor services - no more log warnings and abrupt terminations of a future.
Separate monitors are used for different types of synchronization instead of just synchronizing on 'this'. Potentially, this makes app faster.