### PR TITLE
add compilation of c client to ci. Windows target broken (!)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,6 @@ jdk:
   - oraclejdk8
 
 script:
+  - make ng
+  - make ng.exe
   - scripts/travis_run.sh


### PR DESCRIPTION
The windows build of the C client is broken. Still worked in 0.9.1 but broke some time since.

This demonstrates the existing breakage.