### PR TITLE
Add Python3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
-language: java
-jdk:
-  - oraclejdk8
+language: python
+addons:
+  apt:
+    packages:
+      - oracle-java8-set-default
+python:
+  - "2.7"
+  - "3.5"
+  - "3.6"
 
 script:
   - scripts/travis_run.sh

--- a/pynailgun/test_ng.py
+++ b/pynailgun/test_ng.py
@@ -1,7 +1,6 @@
 import subprocess
 import os
 import time
-import StringIO
 import unittest
 import tempfile
 import shutil
@@ -10,6 +9,11 @@ import sys
 
 from pynailgun import NailgunException, NailgunConnection
 
+is_py2 = sys.version[0] == '2'
+if is_py2:
+    from StringIO import StringIO
+else:
+    from io import StringIO
 
 if os.name == 'posix':
     def transport_exists(transport_file):
@@ -50,7 +54,7 @@ class TestNailgunConnection(unittest.TestCase):
         else:
             pipe_name = u'nailgun-test-{0}'.format(uuid.uuid4().hex)
             self.transport_address = u'local:{0}'.format(pipe_name)
-            self.transport_file = ur'\\.\pipe\{0}'.format(pipe_name)
+            self.transport_file = u'\\\\.\\pipe\{0}'.format(pipe_name)
 
     def getClassPath(self):
         cp = [
@@ -111,7 +115,7 @@ class TestNailgunConnection(unittest.TestCase):
         if os.name == 'posix':
             # on *nix we have to wait for server to be ready to accept connections
             while True:
-                the_first_line = self.ng_server_process.stdout.readline().strip()
+                the_first_line = str(self.ng_server_process.stdout.readline().strip())
                 if "NGServer" in the_first_line and "started" in the_first_line:
                     break
                 if the_first_line is None or the_first_line == '':
@@ -167,7 +171,7 @@ class TestNailgunConnectionMain(TestNailgunConnection):
         super(TestNailgunConnectionMain, self).__init__(*args, **kwargs)
 
     def test_nailgun_stats(self):
-        output = StringIO.StringIO()
+        output = StringIO()
         with NailgunConnection(
                 self.transport_address,
                 stderr=None,
@@ -180,7 +184,7 @@ class TestNailgunConnectionMain(TestNailgunConnection):
         self.assertEqual(actual_out, expected_out)
 
     def test_nailgun_exit_code(self):
-        output = StringIO.StringIO()
+        output = StringIO()
         expected_exit_code = 10
         with NailgunConnection(
                 self.transport_address,
@@ -193,8 +197,8 @@ class TestNailgunConnectionMain(TestNailgunConnection):
     def test_nailgun_stdin(self):
         lines = [str(i) for i in range(100)]
         echo = '\n'.join(lines)
-        output = StringIO.StringIO()
-        input = StringIO.StringIO(echo)
+        output = StringIO()
+        input = StringIO(echo)
         with NailgunConnection(
                 self.transport_address,
                 stderr=None,
@@ -211,7 +215,7 @@ class TestNailgunConnectionMain(TestNailgunConnection):
         self.assertEqual(exit_code, 0)
 
     def test_nailgun_heartbeats(self):
-        output = StringIO.StringIO()
+        output = StringIO()
         with NailgunConnection(
                 self.transport_address,
                 stderr=None,
@@ -224,7 +228,7 @@ class TestNailgunConnectionMain(TestNailgunConnection):
         self.assertTrue(output.getvalue().count('H') > 10)
 
     def test_nailgun_no_heartbeat(self):
-        output = StringIO.StringIO()
+        output = StringIO()
         with NailgunConnection(
                 self.transport_address,
                 stderr=None,
@@ -252,7 +256,7 @@ class TestNailgunConnectionSmallHeartbeatTimeout(TestNailgunConnection):
         Server runs for 30 sec given we still have heartbeats, so it should output about 6 'H'
         We assert that number of 'H' is smaller
         """
-        output = StringIO.StringIO()
+        output = StringIO()
         with NailgunConnection(
                 self.transport_address,
                 stderr=None,

--- a/scripts/travis_run.sh
+++ b/scripts/travis_run.sh
@@ -3,4 +3,6 @@ set -eux
 
 mvn package
 
-python -m pynailgun.test_ng
+export PYTHONPATH=.
+python --version
+python pynailgun/test_ng.py


### PR DESCRIPTION
This PR modifies `pynailgun` to work under both Python 2.7 and Python 3.5/3.6.

Here are some of the changes necessary to be compatible with both Python 2 and 3.
- Being explicit about when we encode and decode between `str` and `bytes`
- Changing imports and import aliasing based on version
- Changing CHUNKTYPEs to use byte literals
- Not using raw string literals (`ur'text'`)
- Wrapping calls to `.fileno()` in a `try`

Additionally it changes the TravisCI build script to test multiple Python versions explicitly.
You can see my changes passes in TravisCI here: https://travis-ci.org/valencik/nailgun

Perhaps of note, I have built and tested these modifications in a fork of https://github.com/scalacenter/bloop and things worked wonders under both Python versions.
Please do let me know if anything else is needed to get this merged.
I am happy to help.

(https://github.com/facebook/nailgun/issues/127)