### PR TITLE
Refactor NGSession.exit procedure

### DIFF
--- a/nailgun-examples/src/main/java/com/martiansoftware/nailgun/examples/Exit.java
+++ b/nailgun-examples/src/main/java/com/martiansoftware/nailgun/examples/Exit.java
@@ -18,6 +18,9 @@ limitations under the License.
 
 package com.martiansoftware.nailgun.examples;
 
+/**
+ * Finish nail with provided exit code
+ */
 public class Exit {
 
 	public static void main (String[] args) {

--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/CommandContext.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/CommandContext.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.martiansoftware.nailgun;
+
+import java.util.List;
+import java.util.Properties;
+
+/**
+ * Provides all information required to run a nail command
+ */
+class CommandContext {
+
+	private final List<String> commandArguments;
+	private final Properties environmentVariables;
+	private final String workingDirectory;
+	private String command; // alias or class name
+	
+	CommandContext(String command, String workingDirectory, Properties environmentVariables, List<String> commandArguments) {
+		this.command = command;
+		this.workingDirectory = workingDirectory;
+		this.environmentVariables = environmentVariables;
+		this.commandArguments = commandArguments;
+	}
+
+	/**
+	 * @return arguments passed with command
+	 */
+	List<String> getCommandArguments() {
+		return commandArguments;
+	}
+
+	/**
+	 * @return Environment variables that nailgun client is executed with
+	 */
+	Properties getEnvironmentVariables() {
+		return environmentVariables;
+	}
+
+	/**
+	 * @return Working directory that nailgun client is executed in
+	 */
+	String getWorkingDirectory() {
+		return workingDirectory;
+	}
+
+	/**
+	 * @return Command name or alias to execute on Nailgun server, i.e. nail class name
+	 */
+	String getCommand() {
+		return command;
+	}
+}

--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGConstants.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGConstants.java
@@ -32,6 +32,10 @@ public class NGConstants {
      */
     public static final int DEFAULT_PORT = 2113;
     /**
+     * The exit code sent to clients if nail completed successfully
+     */
+    public static final int EXIT_SUCCESS = 0;
+    /**
      * The exit code sent to clients if an exception occurred on the server
      */
     public static final int EXIT_EXCEPTION = 899;

--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGContext.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGContext.java
@@ -66,11 +66,6 @@ public class NGContext {
     private String[] args = null;
 
     /**
-     * A stream to which a client exit code can be printed
-     */
-    private PrintStream exitStream = null;
-
-    /**
      * The NGServer that accepted this connection
      */
     private NGServer server = null;
@@ -103,10 +98,6 @@ public class NGContext {
      * Creates a new, empty NGContext
      */
     public NGContext() {
-    }
-
-    public void setExitStream(PrintStream exitStream) {
-        this.exitStream = exitStream;
     }
 
     public void setCommunicator(NGCommunicator comm) {
@@ -231,7 +222,7 @@ public class NGContext {
      * @param exitCode the exit code with which the client should exit
      */
     public void exit(int exitCode) {
-        exitStream.println(exitCode);
+        communicator.exit(exitCode);
     }
 
     /**

--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGSecurityManager.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGSecurityManager.java
@@ -18,66 +18,55 @@ limitations under the License.
 
 package com.martiansoftware.nailgun;
 
-import  java.security.Permission;
+import java.security.Permission;
 
-import  java.io.PrintStream;
+import java.io.PrintStream;
 
 /**
  * Security manager which does nothing other than trap
  * checkExit, or delegate all non-deprecated methods to
  * a base manager.
- * 
+ *
  * @author Pete Kirkham
- * 
  */
 public class NGSecurityManager extends SecurityManager {
-        private static final ThreadLocal EXIT = new InheritableThreadLocal();
-        final SecurityManager base;
-        
-        /**
-         * Construct an NGSecurityManager with the given base.
-         * @param base the base security manager, or null for no base.
-         */
-        public NGSecurityManager (SecurityManager base) {
-                this.base = base;
+    final SecurityManager base;
+
+    /**
+     * Construct an NGSecurityManager with the given base.
+     *
+     * @param base the base security manager, or null for no base.
+     */
+    public NGSecurityManager(SecurityManager base) {
+        this.base = base;
+    }
+
+    public void checkExit(int status) {
+        if (base != null) {
+            base.checkExit(status);
         }
 
-        public void checkExit (int status) {
-                if (base != null) {
-                        base.checkExit(status);
-                }
-                
-                final PrintStream exit = (PrintStream)EXIT.get();
-                
-                if (exit != null) {
-                        exit.println(status);
-                }
-                
-                throw new NGExitException(status);
-        }
+        throw new NGExitException(status);
+    }
 
-        public void checkPermission(Permission perm) {
-                if (base != null) {
-                        base.checkPermission(perm);
-                }
+    public void checkPermission(Permission perm) {
+        if (base != null) {
+            base.checkPermission(perm);
         }
-   
-        public void checkPermission(Permission perm, Object context) {
-                if (base != null) {
-                        base.checkPermission(perm, context);
-                }
-        }
-        
-        public static void setExit (PrintStream exit) {
-                EXIT.set(exit);
-        }
+    }
 
-        /**
-         * Avoid constructing a FilePermission object in checkRead if base manager is null.
-         */
-        public void checkRead(String file) {
-                if (base != null) {
-                        super.checkRead(file);
-                }
+    public void checkPermission(Permission perm, Object context) {
+        if (base != null) {
+            base.checkPermission(perm, context);
         }
+    }
+
+    /**
+     * Avoid constructing a FilePermission object in checkRead if base manager is null.
+     */
+    public void checkRead(String file) {
+        if (base != null) {
+            super.checkRead(file);
+        }
+    }
 }


### PR DESCRIPTION
If NGSession.exit() is called then client is sent with exit code. That causes client to terminate a socket but NGCommunicator uses threads to listen to stdin and heartbeats. If socket is terminated, but nail is not finished yet, this causes that reading thread to unblock, throw and print a naughty message to a log.
The change will process closure gracefully. It stops reading first, sends exit code, then closes the socket. Nail might still continue but it can't read/write from the the socket. Basically, this gives the same as System.exit() but allows the nail code to continue executing.