### PR TITLE
Improving pynailgun command line utility arguments handling

### DIFF
--- a/pynailgun/ng.py
+++ b/pynailgun/ng.py
@@ -17,7 +17,7 @@
 from __future__ import print_function
 import ctypes
 import platform
-import optparse
+import argparse
 import os
 import os.path
 import select
@@ -877,13 +877,13 @@ def main():
     default_nailgun_server = os.environ.get('NAILGUN_SERVER', '127.0.0.1')
     default_nailgun_port = int(os.environ.get('NAILGUN_PORT', NAILGUN_PORT_DEFAULT))
 
-    parser = optparse.OptionParser(usage='%prog [options] cmd arg1 arg2 ...')
-    parser.add_option('--nailgun-server', default=default_nailgun_server)
-    parser.add_option('--nailgun-port', type='int', default=default_nailgun_port)
-    parser.add_option('--nailgun-filearg')
-    parser.add_option('--nailgun-showversion', action='store_true')
-    parser.add_option('--nailgun-help', action='help')
-    (options, args) = parser.parse_args()
+    parser = argparse.ArgumentParser(usage='python ng.py [options] cmd arg1 arg2 ...', add_help=False)
+    parser.add_argument('--nailgun-server', default=default_nailgun_server)
+    parser.add_argument('--nailgun-port', type=int, default=default_nailgun_port)
+    parser.add_argument('--nailgun-filearg')
+    parser.add_argument('--nailgun-showversion', action='store_true')
+    parser.add_argument('--nailgun-help', action='help')
+    (options, args) = parser.parse_known_args()
 
     if options.nailgun_showversion:
         print('NailGun client version ' + NAILGUN_VERSION)


### PR DESCRIPTION
Goals of this pull request:

- Moving from deprecated optparse to argparse
- Separate --nailgun-... arguments from nail (command) arguments

Fixed issue when ng.py show own help, not nail help:

```
> python ng.py org.dcm4che3.tool.storescu.StoreSCU --help
Usage: ng.py [options] cmd arg1 arg2 ...

Options:
  -h, --help            show this help message and exit
  --nailgun-server=NAILGUN_SERVER
  --nailgun-port=NAILGUN_PORT
  --nailgun-filearg=NAILGUN_FILEARG
  --nailgun-showversion
  --nailgun-help
```

Now --help passed to nail, ng.py show help only if argument --nailgun-help passed:

```
> python ng.py org.dcm4che3.tool.storescu.StoreSCU --help
usage: storescu [options] -c <aet>@<host>:<port> [<file>..][<directory>..]
...
```
```
> python ng.py --nailgun-help org.dcm4che3.tool.storescu.StoreSCU --help
usage: python ng.py [options] cmd arg1 arg2 ...

optional arguments:
  --nailgun-server NAILGUN_SERVER
  --nailgun-port NAILGUN_PORT
  --nailgun-filearg NAILGUN_FILEARG
  --nailgun-showversion
  --nailgun-help
```

Fixed issue when arguments not passed to nail (command):

```
> python ng.py org.dcm4che3.tool.storescu.StoreSCU -c user@pacs
Usage: ng.py [options] cmd arg1 arg2 ...

ng.py: error: no such option: -c
```

Now:

```
> python ng.py org.dcm4che3.tool.storescu.StoreSCU -c user@pacs
17:38:15,575 INFO  - Initiate connection from 0.0.0.0/0.0.0.0:0 to pacs:104
17:38:15,575 INFO  - Established connection Socket[addr=/pacs,port=104,localport=60962]
...
```
