### PR TITLE
count bytes (not characters) when sending message

### DIFF
--- a/nailgun-client/py/ng.py
+++ b/nailgun-client/py/ng.py
@@ -797,8 +797,11 @@ def send_thread_main(conn):
             while not conn.send_queue.empty():
                 # only this thread can deplete the queue, so it is safe to use blocking get()
                 (chunk_type, buf) = conn.send_queue.get()
-                struct.pack_into(">ic", header_buf, 0, len(buf), chunk_type)
+
                 bbuf = to_bytes(buf)
+                byte_count=len(bbuf)
+
+                struct.pack_into(">ic", header_buf, 0, byte_count, chunk_type)
 
                 # these chunk types are not required for server to accept and process and server may terminate
                 # any time without waiting for them


### PR DESCRIPTION
For each command, the entire user environment is being send to the server. Any variable in the environment can contain unicodes (e.g. PS1 - prompt configuration)

Sending messages works as follows:
given buffer `buf` (a string):
1. calculate the amount of bytes sent by using `len(buf)`
2. convert `string` to `bytes` using `bbuf = to_bytes(buf)`
3. send the header containing the length of the string message
4. send the actual message

Bug lies in calculating the byte count: it should be calculated using `bytes` buffer, not `string` one.
