### PR TITLE
fix sigpipe on osx

### DIFF
--- a/nailgun-client/c/ng.c
+++ b/nailgun-client/c/ng.c
@@ -803,6 +803,15 @@ int main(int argc, char *argv[], char *env[]) {
     }
   #endif
 
+#ifndef MSG_NOSIGNAL
+#ifdef SO_NOSIGPIPE
+  int option_value = 1;
+  if (setsockopt(nailgunsocket, SOL_SOCKET, SO_NOSIGPIPE, &option_value, sizeof(option_value)) < 0) {
+    perror("setsockopt");
+  }
+#endif
+#endif
+
   if (connect(nailgunsocket, server_addr, server_addr_len) == -1) {
     perror("connect");
     cleanUpAndExit(NAILGUN_CONNECT_FAILED);


### PR DESCRIPTION
Despite being ostensibly a part of POSIX, MSG_NOSIGNAL is not defined in Mac OS. This causes nailgun to intermittently raise SIGPIPE on that platform, which in turn makes nails sometimes return exit status 141 when they should succeed and return exit status 0. This was breaking my Mac OS build of https://github.com/kframework/k.

Here we make use of the alternative, OSX-specific API SO_NOSIGPIPE to fix the same problem. this has been tested against the K test suite and makes it pass on Mac OS X.