### PR TITLE
Add handling of error 233 on Windows (no process on the other side of the pipe)

### DIFF
--- a/nailgun-client/py/ng.py
+++ b/nailgun-client/py/ng.py
@@ -179,6 +179,9 @@ if os.name == "nt":
     ERROR_IO_PENDING = 0x000003E5
     ERROR_PIPE_BUSY = 231
 
+    # No process is on the other end of the pipe error on Windows
+    ERROR_NO_PROCESS_ON_OTHER_END_OF_PIPE = 233
+
     # The pointer size follows the architecture
     # We use WPARAM since this type is already conditionally defined
     ULONG_PTR = ctypes.wintypes.WPARAM
@@ -366,6 +369,13 @@ class WindowsNamedPipeTransport(Transport):
         olap.hEvent = self.read_waitable
 
         immediate = ReadFile(self.pipe, buf, nbytes, None, olap)
+
+        err = GetLastError()
+
+        if err == ERROR_NO_PROCESS_ON_OTHER_END_OF_PIPE:
+            raise NailgunException(
+                "No process on the other end of pipe", NailgunException.CONNECTION_BROKEN
+            )
 
         if not immediate:
             err = GetLastError()


### PR DESCRIPTION
When a process dies (exiting or any other reason) the pipe nailgun talks to might be left in dangling state. Make sure nailgun deals with this state properly.