### PR TITLE
Fix EXIT chunk being sent twice

### DIFF
--- a/nailgun-server/src/main/java/com/facebook/nailgun/NGCommunicator.java
+++ b/nailgun-server/src/main/java/com/facebook/nailgun/NGCommunicator.java
@@ -338,7 +338,7 @@ public class NGCommunicator implements Closeable {
 
     // send the command - client will exit
     try (PrintStream exit = new PrintStream(new NGOutputStream(this, NGConstants.CHUNKTYPE_EXIT))) {
-      exit.println(exitCode);
+      exit.print(exitCode);
     }
     isExited = true;
 

--- a/nailgun-server/src/test/java/com/facebook/nailgun/NGCommunicatorTest.java
+++ b/nailgun-server/src/test/java/com/facebook/nailgun/NGCommunicatorTest.java
@@ -18,6 +18,7 @@ limitations under the License.
 
 package com.facebook.nailgun;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
@@ -88,5 +89,16 @@ class NGCommunicatorTest {
     comm.send(NGConstants.CHUNKTYPE_STDOUT, data, 0, data.length);
 
     verify(ostream).write(data, 0, data.length);
+  }
+
+  @Test
+  void canSendExitCode() throws IOException {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    when(socket.getOutputStream()).thenReturn(output);
+
+    NGCommunicator comm = new NGCommunicator(socket, 0);
+    comm.exit(42);
+
+    assertArrayEquals(new byte[] {0x00, 0x00, 0x00, 0x02, 'X', '4', '2'}, output.toByteArray());
   }
 }


### PR DESCRIPTION
The server was sending the expected EXIT chunk, followed by an EXIT
chunk containing a newline character.