### PR TITLE
[python3] Ensure UTF8 strings are sent properly

### DIFF
--- a/nailgun-client/py/ng.py
+++ b/nailgun-client/py/ng.py
@@ -834,8 +834,8 @@ def send_thread_main(conn):
             while not conn.send_queue.empty():
                 # only this thread can deplete the queue, so it is safe to use blocking get()
                 (chunk_type, buf) = conn.send_queue.get()
-                struct.pack_into(">ic", header_buf, 0, len(buf), chunk_type)
                 bbuf = to_bytes(buf)
+                struct.pack_into(">ic", header_buf, 0, len(bbuf), chunk_type)
 
                 # these chunk types are not required for server to accept and process and server may terminate
                 # any time without waiting for them

--- a/nailgun-client/py/test_ng.py
+++ b/nailgun-client/py/test_ng.py
@@ -77,8 +77,8 @@ class TestNailgunConnection(unittest.TestCase):
 
     def getClassPath(self):
         cp = [
-            "nailgun-server/target/nailgun-server-1.0.0-uber.jar",
-            "nailgun-examples/target/nailgun-examples-1.0.0.jar",
+            "nailgun-server/target/nailgun-server-1.0.1-uber.jar",
+            "nailgun-examples/target/nailgun-examples-1.0.1.jar",
         ]
         if os.name == "nt":
             return ";".join(cp)
@@ -215,6 +215,22 @@ class TestNailgunConnectionMain(TestNailgunConnection):
         actual_out = output.getvalue().strip()
         expected_out = "com.facebook.nailgun.builtins.NGServerStats: 1/1"
         self.assertEqual(actual_out, expected_out)
+
+    def test_nailgun_with_utf8_environ(self):
+        output = StringIO()
+        with NailgunConnection(
+            self.transport_address, stderr=None, stdin=None, stdout=output
+        ) as c:
+            env = os.environ.copy()
+            # foo <BOX DRAWINGS LIGHT DOWN AND RIGHT> <BOX DRAWINGS LIGHT HORIZONTAL> bar
+            env["WITH_UTF8"] = "foo\xe2\x94\x8c\xe2\x94\x80bar"
+            exit_code = c.send_command("ng-stats", env=env)
+
+        self.assertEqual(exit_code, 0)
+        actual_out = output.getvalue().strip()
+        expected_out = "com.facebook.nailgun.builtins.NGServerStats: 1/1"
+        self.assertEqual(actual_out, expected_out)
+
 
     def test_nailgun_exit_code(self):
         output = StringIO()


### PR DESCRIPTION
Previously we'd take a `buf` (the data to send), use that length in the
framing that we sent (`<ic` in sendall), and then send a binary buffer.

This caused problems when people had UTF8 strings in their environment
under python3, as `len(buf)` is the number of chars, and `len(bbuf)` is
the number of bytes. Multi-byte characters thus sent more data than the
server was expect. This was not a problem in python2, as os.environ just
reads these as binary strings and len() returns the number of bytes.

Test Plan:
Added a new unittest that failed under python3 previously, and passes
now under python2 + python3