### PR TITLE
[travis] Fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 addons:
   apt:
     packages:
-      - oracle-java8-installer
+      - openjdk-8-jdk
       - mingw-w64
 python:
   - "2.7"

--- a/scripts/travis_run.sh
+++ b/scripts/travis_run.sh
@@ -17,6 +17,13 @@
 
 set -eux
 
+export JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
+if [ ! -d "$JAVA_HOME" ]; then
+  echo "Could not find ${JAVA_HOME}. Try one of these?"
+  find /usr/lib/jvm -type d
+  exit 1
+fi
+
 mvn package
 
 export PYTHONPATH=.


### PR DESCRIPTION
Oracle jdk 8 doesn't seem to be available anymore. Just use
openjdk-8-jdk. We're not using anything super fancy that would
only be in Oracle JDK