### PR TITLE
[python3] Remove bytes -> str conversion

### DIFF
--- a/nailgun-examples/src/main/java/com/facebook/nailgun/examples/BinaryEcho.java
+++ b/nailgun-examples/src/main/java/com/facebook/nailgun/examples/BinaryEcho.java
@@ -1,0 +1,32 @@
+/*
+  Copyright 2004-2012, Martian Software, Inc.
+  Copyright 2017-Present Facebook, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+package com.facebook.nailgun.examples;
+
+/**
+ * Echoes some 'N' binary blobs back over stdout
+ */
+public class BinaryEcho {
+
+  public static void main(String[] args) throws Exception {
+    int toPrint = Integer.parseInt(args[0]);
+    for(int i = 0; i < toPrint; i++) {
+      System.out.write(0xe2);
+    }
+    System.out.flush();
+  }
+}


### PR DESCRIPTION
This was incorrectly done during the python3 migration. stdout/err only
accepts strings in python3, so we were converting to utf-8, which is not
always the right behavior. Instead write to std*.buffer, and flush after
each write.

Tested in buck with python3, and it handles non-utf8 coming over ng now
where it didn't before