### PR TITLE
Replace StringBuffer by StringBuilder

### DIFF
--- a/nailgun-server/src/main/java/com/facebook/nailgun/builtins/NGAlias.java
+++ b/nailgun-server/src/main/java/com/facebook/nailgun/builtins/NGAlias.java
@@ -47,7 +47,7 @@ import java.util.Set;
 public class NGAlias {
 
   private static String padl(String s, int len) {
-    StringBuffer buf = new StringBuffer(s);
+    StringBuilder buf = new StringBuilder(s);
     while (buf.length() < len) buf.append(" ");
     return (buf.toString());
   }


### PR DESCRIPTION
Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

Early classes of the Java API, such as Vector, Hashtable and StringBuffer, were synchronized to make them thread-safe. Unfortunately, synchronization has a big negative impact on performance, even when using these collections from a single thread.

It is better to use their new unsynchronized replacements:
- ArrayList or LinkedList instead of Vector
- Deque instead of Stack
- HashMap instead of Hashtable
- StringBuilder instead of StringBuffer