### PR TITLE
Feature/ng constants no public constructor

### DIFF
--- a/nailgun-server/src/main/java/com/facebook/nailgun/NGConstants.java
+++ b/nailgun-server/src/main/java/com/facebook/nailgun/NGConstants.java
@@ -27,6 +27,8 @@ import java.util.Properties;
  */
 public class NGConstants {
 
+  private NGConstants() {}
+
   /** The default NailGun port (2113) */
   public static final int DEFAULT_PORT = 2113;
   /** The exit code sent to clients if nail completed successfully */

--- a/nailgun-server/src/main/java/com/facebook/nailgun/builtins/NGAlias.java
+++ b/nailgun-server/src/main/java/com/facebook/nailgun/builtins/NGAlias.java
@@ -47,7 +47,7 @@ import java.util.Set;
 public class NGAlias {
 
   private static String padl(String s, int len) {
-    StringBuffer buf = new StringBuffer(s);
+    StringBuilder buf = new StringBuilder(s);
     while (buf.length() < len) buf.append(" ");
     return (buf.toString());
   }


### PR DESCRIPTION
Utility classes should not have public constructors

Utility classes, which are collections of static members, are not meant to be instantiated. Even abstract utility classes, which can be extended, should not have public constructors.

Java adds an implicit public constructor to every class which does not define at least one explicitly. Hence, at least one non-public constructor should be defined.