### PR TITLE
Remove public constructor from NGConstants utility class

### DIFF
--- a/nailgun-server/src/main/java/com/facebook/nailgun/NGConstants.java
+++ b/nailgun-server/src/main/java/com/facebook/nailgun/NGConstants.java
@@ -27,6 +27,8 @@ import java.util.Properties;
  */
 public class NGConstants {
 
+  private NGConstants() {}
+
   /** The default NailGun port (2113) */
   public static final int DEFAULT_PORT = 2113;
   /** The exit code sent to clients if nail completed successfully */


### PR DESCRIPTION
Utility classes should not have public constructors

Utility classes, which are collections of static members, are not meant to be instantiated. Even abstract utility classes, which can be extended, should not have public constructors.

Java adds an implicit public constructor to every class which does not define at least one explicitly. Hence, at least one non-public constructor should be defined.