### PR TITLE
Add Override annotation to NGExitException

### DIFF
--- a/nailgun-server/src/main/java/com/facebook/nailgun/NGExitException.java
+++ b/nailgun-server/src/main/java/com/facebook/nailgun/NGExitException.java
@@ -87,6 +87,7 @@ public class NGExitException extends SecurityException {
    * will squash this exception; most also calll printStackTrace(), so this re-throws the exception
    * to escape the handling code.
    */
+  @Override
   public void printStackTrace(PrintStream out) {
     throw this;
   }


### PR DESCRIPTION
NGExitException extends SecurityException. Method overrides `printStackTrace` method should me annoteted with `@Override`.