### PR TITLE
Make NGServerContext static class

### DIFF
--- a/nailgun-server/src/test/java/com/facebook/nailgun/NGServerTest.java
+++ b/nailgun-server/src/test/java/com/facebook/nailgun/NGServerTest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 class NGServerTest {
 
   /** Encapsulate information about running NGServer */
-  private class NGServerContext {
+  private static class NGServerContext {
     public NGServerContext(NGServer server, Thread thread) {
       this.server = server;
       this.thread = thread;


### PR DESCRIPTION
This class is an inner class, but does not use its embedded reference to the object which created it.  This reference makes the instances of the class larger, and may keep the reference to the creator object alive longer than necessary.  If possible, the class should be made static.