### PR TITLE
No busy looping in select on Windows

### DIFF
--- a/nailgun-client/py/ng.py
+++ b/nailgun-client/py/ng.py
@@ -25,6 +25,7 @@ import select
 import socket
 import struct
 import sys
+import time
 from io import BytesIO
 from threading import Condition, Event, Thread, RLock
 
@@ -442,6 +443,9 @@ class WindowsNamedPipeTransport(Transport):
                 or monotonic_time_nanos() - start > timeout_nanos
             ):
                 return readable, exceptional
+            
+            # Sleep a bit to avoid busy looping for no reason.
+            time.sleep(0.05)
 
     def select_now(self):
         available_total = wintypes.DWORD()


### PR DESCRIPTION
On Windows, the PeekNamedPipe will as expected immediately return, but this has
the negative side effect of making the `select` function a busy loop,
effectively using a full core. In the case of buck, this ultimately causes compiling to
be slower than they should be.

As a workaround, let's just sleep a bit in select if nothing can be read from
the named pipe.